### PR TITLE
Updated links to Travis, AppVeyor and Coveralls. Removed links to Codacy and Gitter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,11 +1,9 @@
 = Address Book (Level 4)
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 
-https://travis-ci.org/se-edu/addressbook-level4[image:https://travis-ci.org/se-edu/addressbook-level4.svg?branch=master[Build Status]]
-https://ci.appveyor.com/project/damithc/addressbook-level4[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
-https://coveralls.io/github/se-edu/addressbook-level4?branch=master[image:https://coveralls.io/repos/github/se-edu/addressbook-level4/badge.svg?branch=master[Coverage Status]]
-https://www.codacy.com/app/damith/addressbook-level4?utm_source=github.com&utm_medium=referral&utm_content=se-edu/addressbook-level4&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a[Codacy Badge]]
-https://gitter.im/se-edu/Lobby[image:https://badges.gitter.im/se-edu/Lobby.svg[Gitter chat]]
+https://travis-ci.org/CS2103JAN2018-W14-B3/main[image:https://travis-ci.org/CS2103JAN2018-W14-B3/main.svg?branch=master[Build Status]]
+https://ci.appveyor.com/project/tanhengyeow/main[image:https://ci.appveyor.com/api/projects/status/eakk9eghorankpv3?svg=true[Build status]]
+https://coveralls.io/github/CS2103JAN2018-W14-B3/main?branch=master[image:https://coveralls.io/repos/github/CS2103JAN2018-W14-B3/main/badge.svg?branch=master[Coverage Status]]
 
 ifdef::env-github[]
 image::docs/images/Ui.png[width="600"]


### PR DESCRIPTION
As per title.