### PR TITLE
Improved find command

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -98,15 +98,17 @@ Edits the phone number and email address of the 1st person to be `91234567` and 
 * `edit 2 n/Betsy Crower t/` +
 Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 
-=== Locating persons by name: `find`
+=== Locating persons by field: `find`
 
-Finds persons whose names contain any of the given keywords. +
-Format: `find KEYWORD [MORE_KEYWORDS]`
+Finds persons whose fields contain any of the given keywords. +
+Format:
+Option 1: `find KEYWORD [MORE_KEYWORDS]`
+Option 2: `find prefix/KEYWORD [MORE KEYWORDS] prefix/...`
 
 ****
 * The search is case insensitive. e.g `hans` will match `Hans`
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
-* Only the name is searched.
+* All fields are searched if no prefix is supplied.
 * Only full words will be matched e.g. `Han` will not match `Hans`
 * Persons matching at least one keyword will be returned (i.e. `OR` search). e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
 ****
@@ -117,6 +119,10 @@ Examples:
 Returns `john` and `John Doe`
 * `find Betsy Tim John` +
 Returns any person having names `Betsy`, `Tim`, or `John`
+* `find p/999 555` +
+Returns any person having phone number `999` or `555`
+* `find p/999 e/test@example.com`
+Returns any person having phone number `999` and email `test@example.com`
 
 === Filter persons by expected graduation year: `filter`
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,23 +1,27 @@
 package seedu.address.logic.commands;
 
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import java.util.function.Predicate;
+
+import seedu.address.model.person.Person;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all persons in address book whose field contains any of the argument keywords.
  * Keyword matching is case sensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose fields contain any of "
             + "the specified keywords (case-sensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Option 1 (Search all fields): KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " alex david alexyeoh@example.com\n\n"
+            + "Option 2 (Search by prefixs): /n[KEYWORD] [MORE_KEYWORDS] /p...\n"
+            + "Example: " + COMMAND_WORD + " n/Alex Bernice p/999 555";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<Person> predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate<Person> predicate) {
         this.predicate = predicate;
     }
 
@@ -32,5 +36,9 @@ public class FindCommand extends Command {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
                 && this.predicate.equals(((FindCommand) other).predicate)); // state check
+    }
+
+    public Predicate<Person> getPredicate() {
+        return predicate;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.AddressContainsKeywordsPredicate;
@@ -49,56 +50,58 @@ public class FindCommandParser implements Parser<FindCommand> {
         Predicate<Person> finalPredicate;
         boolean isGlobalSearch = false;
 
-        // no prefix used, search for all fields (global search)
-        if (!startWithPrefix(trimmedArgs)) {
-            isGlobalSearch = true;
-            String[] keywords = trimmedArgs.split("\\s+");
+        try {
+            // no prefix used, search for all fields (global search)
+            if (!startWithPrefix(trimmedArgs)) {
+                isGlobalSearch = true;
+                String[] keywords = trimmedArgs.split("\\s+");
 
-            predicateList.add(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
-            predicateList.add(new PhoneContainsKeywordsPredicate(Arrays.asList(keywords)));
-            predicateList.add(new EmailContainsKeywordsPredicate(Arrays.asList(keywords)));
-            predicateList.add(new AddressContainsKeywordsPredicate(Arrays.asList(keywords)));
-            predicateList.add(new ExpectedGraduationYearContainsKeywordsPredicate(Arrays.asList(keywords)));
+                predicateList.add(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+                predicateList.add(new PhoneContainsKeywordsPredicate(Arrays.asList(keywords)));
+                predicateList.add(new EmailContainsKeywordsPredicate(Arrays.asList(keywords)));
+                predicateList.add(new AddressContainsKeywordsPredicate(Arrays.asList(keywords)));
+                predicateList.add(new ExpectedGraduationYearContainsKeywordsPredicate(Arrays.asList(keywords)));
 
-            finalPredicate = combinePredicates(isGlobalSearch, predicateList.toArray(new Predicate[predicateList.size()]));
+                finalPredicate = combinePredicates(isGlobalSearch,
+                        predicateList.toArray(new Predicate[predicateList.size()]));
+                return new FindCommand(finalPredicate);
+            }
+
+            // at least one prefix is used, search for fields that matches prefix only
+            if (!argMultimap.getPreamble().isEmpty()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+
+            // checks if prefix is present in argMultimap and adds the corresponding predicate to predicateList
+            if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+                String[] nameKeywords = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
+                predicateList.add(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+            }
+            if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+                String[] phoneKeywords = argMultimap.getValue(PREFIX_PHONE).get().split("\\s+");
+                predicateList.add(new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeywords)));
+            }
+            if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+                String[] emailKeywords = argMultimap.getValue(PREFIX_EMAIL).get().split("\\s+");
+                predicateList.add(new EmailContainsKeywordsPredicate(Arrays.asList(emailKeywords)));
+            }
+            if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
+                String[] addressKeywords = argMultimap.getValue(PREFIX_ADDRESS).get().split("\\s+");
+                predicateList.add(new AddressContainsKeywordsPredicate(Arrays.asList(addressKeywords)));
+            }
+            if (argMultimap.getValue(PREFIX_EXPECTED_GRADUATION_YEAR).isPresent()) {
+                String[] expectedGraduationYearKeywords =
+                        argMultimap.getValue(PREFIX_EXPECTED_GRADUATION_YEAR).get().split("\\s+");
+                predicateList.add(new ExpectedGraduationYearContainsKeywordsPredicate(
+                                  Arrays.asList(expectedGraduationYearKeywords)));
+            }
+
+            finalPredicate = combinePredicates(isGlobalSearch,
+                                               predicateList.toArray(new Predicate[predicateList.size()]));
             return new FindCommand(finalPredicate);
+        } catch (IllegalValueException ive) {
+            throw new ParseException(ive.getMessage(), ive);
         }
-
-        // at least one prefix is used, search for fields that matches prefix only
-        if (!argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        }
-
-        String[] nameKeywords,
-                phoneKeywords,
-                emailKeywords,
-                addressKeywords,
-                expectedGraduationYearKeywords;
-
-        // checks if prefix is present in argMultimap and adds the corresponding predicate to predicateList
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            nameKeywords = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
-            predicateList.add(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
-        }
-        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            phoneKeywords = argMultimap.getValue(PREFIX_PHONE).get().split("\\s+");
-            predicateList.add(new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeywords)));
-        }
-        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            emailKeywords = argMultimap.getValue(PREFIX_EMAIL).get().split("\\s+");
-            predicateList.add(new EmailContainsKeywordsPredicate(Arrays.asList(emailKeywords)));
-        }
-        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            addressKeywords = argMultimap.getValue(PREFIX_ADDRESS).get().split("\\s+");
-            predicateList.add(new AddressContainsKeywordsPredicate(Arrays.asList(addressKeywords)));
-        }
-        if (argMultimap.getValue(PREFIX_EXPECTED_GRADUATION_YEAR).isPresent()) {
-            expectedGraduationYearKeywords = argMultimap.getValue(PREFIX_EXPECTED_GRADUATION_YEAR).get().split("\\s+");
-            predicateList.add(new ExpectedGraduationYearContainsKeywordsPredicate(Arrays.asList(expectedGraduationYearKeywords)));
-        }
-
-        finalPredicate = combinePredicates(isGlobalSearch, predicateList.toArray(new Predicate[predicateList.size()]));
-        return new FindCommand(finalPredicate);
     }
 
     /**
@@ -107,25 +110,25 @@ public class FindCommandParser implements Parser<FindCommand> {
     private boolean startWithPrefix(String trimmedArgs) {
         String[] args = trimmedArgs.split("\\s+");
 
-        return (args[0].contains(PREFIX_NAME.toString()) ||
-                args[0].contains(PREFIX_PHONE.toString()) ||
-                args[0].contains(PREFIX_EMAIL.toString()) ||
-                args[0].contains(PREFIX_ADDRESS.toString()) ||
-                args[0].contains(PREFIX_EXPECTED_GRADUATION_YEAR.toString()));
+        return (args[0].contains(PREFIX_NAME.toString())
+                || args[0].contains(PREFIX_PHONE.toString())
+                || args[0].contains(PREFIX_EMAIL.toString())
+                || args[0].contains(PREFIX_ADDRESS.toString())
+                || args[0].contains(PREFIX_EXPECTED_GRADUATION_YEAR.toString()));
     }
 
     /**
-     * Combines all predicates in predicateList that matches the corresponding condition to form finalPredicate
+     * Combines all predicates in {@code predicateList} that matches the
+     * corresponding condition to form {@code finalPredicate}
      * @param predicates in the form of varargs
-     * @return finalPredicate of Predicate<Person>
+     * @return {@code finalPredicate} of type {@code Predicate<Person>}
      */
     private Predicate<Person> combinePredicates(boolean isGlobalSearch, Predicate<Person>... predicates) {
         Predicate<Person> finalPredicate;
 
         if (isGlobalSearch) {
             finalPredicate = Stream.of(predicates).reduce(condition -> false, Predicate::or);
-        }
-        else {
+        } else {
             finalPredicate = Stream.of(predicates).reduce(condition -> true, Predicate::and);
         }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,26 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPECTED_GRADUATION_YEAR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.ExpectedGraduationYearContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -19,15 +33,102 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
+
+        // Check for empty argument input
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_EXPECTED_GRADUATION_YEAR); // more fields to be added if necessary
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        List<Predicate<Person>> predicateList = new ArrayList<>();
+        Predicate<Person> finalPredicate;
+        boolean isGlobalSearch = false;
+
+        // no prefix used, search for all fields (global search)
+        if (!startWithPrefix(trimmedArgs)) {
+            isGlobalSearch = true;
+            String[] keywords = trimmedArgs.split("\\s+");
+
+            predicateList.add(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+            predicateList.add(new PhoneContainsKeywordsPredicate(Arrays.asList(keywords)));
+            predicateList.add(new EmailContainsKeywordsPredicate(Arrays.asList(keywords)));
+            predicateList.add(new AddressContainsKeywordsPredicate(Arrays.asList(keywords)));
+            predicateList.add(new ExpectedGraduationYearContainsKeywordsPredicate(Arrays.asList(keywords)));
+
+            finalPredicate = combinePredicates(isGlobalSearch, predicateList.toArray(new Predicate[predicateList.size()]));
+            return new FindCommand(finalPredicate);
+        }
+
+        // at least one prefix is used, search for fields that matches prefix only
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords,
+                phoneKeywords,
+                emailKeywords,
+                addressKeywords,
+                expectedGraduationYearKeywords;
+
+        // checks if prefix is present in argMultimap and adds the corresponding predicate to predicateList
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            nameKeywords = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
+            predicateList.add(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            phoneKeywords = argMultimap.getValue(PREFIX_PHONE).get().split("\\s+");
+            predicateList.add(new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            emailKeywords = argMultimap.getValue(PREFIX_EMAIL).get().split("\\s+");
+            predicateList.add(new EmailContainsKeywordsPredicate(Arrays.asList(emailKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
+            addressKeywords = argMultimap.getValue(PREFIX_ADDRESS).get().split("\\s+");
+            predicateList.add(new AddressContainsKeywordsPredicate(Arrays.asList(addressKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_EXPECTED_GRADUATION_YEAR).isPresent()) {
+            expectedGraduationYearKeywords = argMultimap.getValue(PREFIX_EXPECTED_GRADUATION_YEAR).get().split("\\s+");
+            predicateList.add(new ExpectedGraduationYearContainsKeywordsPredicate(Arrays.asList(expectedGraduationYearKeywords)));
+        }
+
+        finalPredicate = combinePredicates(isGlobalSearch, predicateList.toArray(new Predicate[predicateList.size()]));
+        return new FindCommand(finalPredicate);
     }
 
+    /**
+     * Returns whether the user starts with a prefix in the argument as a boolean result.
+     */
+    private boolean startWithPrefix(String trimmedArgs) {
+        String[] args = trimmedArgs.split("\\s+");
+
+        return (args[0].contains(PREFIX_NAME.toString()) ||
+                args[0].contains(PREFIX_PHONE.toString()) ||
+                args[0].contains(PREFIX_EMAIL.toString()) ||
+                args[0].contains(PREFIX_ADDRESS.toString()) ||
+                args[0].contains(PREFIX_EXPECTED_GRADUATION_YEAR.toString()));
+    }
+
+    /**
+     * Combines all predicates in predicateList that matches the corresponding condition to form finalPredicate
+     * @param predicates in the form of varargs
+     * @return finalPredicate of Predicate<Person>
+     */
+    private Predicate<Person> combinePredicates(boolean isGlobalSearch, Predicate<Person>... predicates) {
+        Predicate<Person> finalPredicate;
+
+        if (isGlobalSearch) {
+            finalPredicate = Stream.of(predicates).reduce(condition -> false, Predicate::or);
+        }
+        else {
+            finalPredicate = Stream.of(predicates).reduce(condition -> true, Predicate::and);
+        }
+
+        return finalPredicate;
+    }
 }

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Address} matches any of the keywords given.
+ */
+public class AddressContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public AddressContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getAddress().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddressContainsKeywordsPredicate // instanceof handles nulls
+                && this.keywords.equals(((AddressContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Email} matches any of the keywords given.
+ */
+public class EmailContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public EmailContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EmailContainsKeywordsPredicate // instanceof handles nulls
+                && this.keywords.equals(((EmailContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/ExpectedGraduationYearContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ExpectedGraduationYearContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code ExpectedGraduationYear} matches any of the keywords given.
+ */
+public class ExpectedGraduationYearContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public ExpectedGraduationYearContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getExpectedGraduationYear().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ExpectedGraduationYearContainsKeywordsPredicate // instanceof handles nulls
+                && this.keywords.equals(((ExpectedGraduationYearContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/ExpectedGraduationYearContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ExpectedGraduationYearContainsKeywordsPredicate.java
@@ -18,14 +18,16 @@ public class ExpectedGraduationYearContainsKeywordsPredicate implements Predicat
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getExpectedGraduationYear().value, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase
+                        (person.getExpectedGraduationYear().value, keyword));
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ExpectedGraduationYearContainsKeywordsPredicate // instanceof handles nulls
-                && this.keywords.equals(((ExpectedGraduationYearContainsKeywordsPredicate) other).keywords)); // state check
+                && this.keywords.equals(((
+                        ExpectedGraduationYearContainsKeywordsPredicate) other).keywords)); // state check
     }
 
 }

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ */
+public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public PhoneContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PhoneContainsKeywordsPredicate // instanceof handles nulls
+                && this.keywords.equals(((PhoneContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -31,7 +31,6 @@ import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.ExpectedGraduationYearBeforeKeywordPredicate;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -81,9 +80,10 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertTrue(parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")))
+                instanceof FindCommand);
+        assertTrue(parser.parseCommand(FindCommand.COMMAND_WORD + " n/foo") instanceof FindCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -2,14 +2,10 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-
-import java.util.Arrays;
 
 import org.junit.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -19,16 +15,4 @@ public class FindCommandParserTest {
     public void parse_emptyArg_throwsParseException() {
         assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
-
-    @Test
-    public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
-
-        // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
-    }
-
 }

--- a/src/test/java/seedu/address/model/person/AddressContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/AddressContainsKeywordsPredicateTest.java
@@ -1,0 +1,80 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class AddressContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("Kent Ridge Drive");
+        List<String> secondPredicateKeywordList = Arrays.asList("Kent Ridge Drive", "Computing Drive");
+
+        AddressContainsKeywordsPredicate firstPredicate =
+                new AddressContainsKeywordsPredicate(firstPredicateKeywordList);
+        AddressContainsKeywordsPredicate secondPredicate =
+                new AddressContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        AddressContainsKeywordsPredicate firstPredicateCopy =
+                new AddressContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_addressContainsKeywords_returnsTrue() {
+        // One keyword
+        AddressContainsKeywordsPredicate predicate =
+                new AddressContainsKeywordsPredicate(Collections.singletonList("Computing"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("Computing Drive").build()));
+
+        // Multiple keywords
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("Computing", "Drive"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("Kent Ridge Drive").build()));
+
+        // Only one matching keyword
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("Computing", "Test"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("Computing Drive").build()));
+
+        // Mixed-case keywords
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("comPuTing", "dRivE"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("Computing Drive").build()));
+    }
+
+    @Test
+    public void test_addressDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        AddressContainsKeywordsPredicate predicate =
+                new AddressContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withAddress("Computing Drive").build()));
+
+        // Non-matching keyword
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("Compting"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Computing Drive").build()));
+
+        // Keywords match phone, email, expected graduation year and name, but does not match address
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Alice", "2020"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+                .withEmail("alice@email.com").withAddress("Main Street").withExpectedGraduationYear("2020").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/EmailContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/EmailContainsKeywordsPredicateTest.java
@@ -1,0 +1,73 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class EmailContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("hy@example.com");
+        List<String> secondPredicateKeywordList = Arrays.asList("hy@example.com", "yh@example.com");
+
+        EmailContainsKeywordsPredicate firstPredicate =
+                new EmailContainsKeywordsPredicate(firstPredicateKeywordList);
+        EmailContainsKeywordsPredicate secondPredicate =
+                new EmailContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        EmailContainsKeywordsPredicate firstPredicateCopy =
+                new EmailContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_emailContainsKeywords_returnsTrue() {
+        // One keyword
+        EmailContainsKeywordsPredicate predicate =
+                new EmailContainsKeywordsPredicate(Collections.singletonList("hy@example.com"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("hy@example.com").build()));
+
+        // Multiple keywords
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("hy@example.com", "yh@example.com"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("hy@example.com").build()));
+    }
+
+    @Test
+    public void test_emailDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        EmailContainsKeywordsPredicate predicate =
+                new EmailContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withEmail("hy@lol.com").build()));
+
+        // Non-matching keyword
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("lol@lol.com"));
+        assertFalse(predicate.test(new PersonBuilder().withEmail("hy@example.com").build()));
+
+        // Keywords match phone, name, expected graduation year and address, but does not match email
+        predicate = new EmailContainsKeywordsPredicate(
+                Arrays.asList("12345", "Alice", "Main", "Street", "2020"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+                .withEmail("alice@email.com").withAddress("Main Street").withExpectedGraduationYear("2020").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/ExpectedGraduationYearContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/ExpectedGraduationYearContainsKeywordsPredicateTest.java
@@ -1,0 +1,73 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class ExpectedGraduationYearContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("2020");
+        List<String> secondPredicateKeywordList = Arrays.asList("2020", "2019");
+
+        ExpectedGraduationYearContainsKeywordsPredicate firstPredicate =
+                new ExpectedGraduationYearContainsKeywordsPredicate(firstPredicateKeywordList);
+        ExpectedGraduationYearContainsKeywordsPredicate secondPredicate =
+                new ExpectedGraduationYearContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        ExpectedGraduationYearContainsKeywordsPredicate firstPredicateCopy =
+                new ExpectedGraduationYearContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_expectedGraduationYearContainsKeywords_returnsTrue() {
+        // One keyword
+        ExpectedGraduationYearContainsKeywordsPredicate predicate =
+                new ExpectedGraduationYearContainsKeywordsPredicate(Collections.singletonList("2020"));
+        assertTrue(predicate.test(new PersonBuilder().withExpectedGraduationYear("2020").build()));
+
+        // Multiple keywords
+        predicate = new ExpectedGraduationYearContainsKeywordsPredicate(Arrays.asList("2020", "2019"));
+        assertTrue(predicate.test(new PersonBuilder().withExpectedGraduationYear("2020").build()));
+    }
+
+    @Test
+    public void test_expectedGraduationYearDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        ExpectedGraduationYearContainsKeywordsPredicate predicate =
+                new ExpectedGraduationYearContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withExpectedGraduationYear("2020").build()));
+
+        // Non-matching keyword
+        predicate = new ExpectedGraduationYearContainsKeywordsPredicate(Arrays.asList("2025"));
+        assertFalse(predicate.test(new PersonBuilder().withName("2020").build()));
+
+        // Keywords match phone, email, name and address, but does not match expected graduation year
+        predicate = new ExpectedGraduationYearContainsKeywordsPredicate(
+                Arrays.asList("12345", "alice@email.com", "Alice", "Main", "Street"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+                .withEmail("alice@email.com").withAddress("Main Street").withExpectedGraduationYear("2020").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -18,14 +18,17 @@ public class NameContainsKeywordsPredicateTest {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
-        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
-        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(secondPredicateKeywordList);
+        NameContainsKeywordsPredicate firstPredicate =
+                new NameContainsKeywordsPredicate(firstPredicateKeywordList);
+        NameContainsKeywordsPredicate secondPredicate =
+                new NameContainsKeywordsPredicate(secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        NameContainsKeywordsPredicate firstPredicateCopy = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
+        NameContainsKeywordsPredicate firstPredicateCopy =
+                new NameContainsKeywordsPredicate(firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -41,7 +44,8 @@ public class NameContainsKeywordsPredicateTest {
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
+        NameContainsKeywordsPredicate predicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Multiple keywords
@@ -67,9 +71,10 @@ public class NameContainsKeywordsPredicateTest {
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
-        // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
+        // Keywords match phone, email, expected graduation year and address, but does not match name
+        predicate = new NameContainsKeywordsPredicate(
+                Arrays.asList("12345", "alice@email.com", "Main", "Street", "2020"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@email.com").withAddress("Main Street").build()));
+                .withEmail("alice@email.com").withAddress("Main Street").withExpectedGraduationYear("2020").build()));
     }
 }

--- a/src/test/java/seedu/address/model/person/PhoneContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneContainsKeywordsPredicateTest.java
@@ -1,0 +1,74 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class PhoneContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("999");
+        List<String> secondPredicateKeywordList = Arrays.asList("999", "555");
+
+        PhoneContainsKeywordsPredicate firstPredicate = new PhoneContainsKeywordsPredicate(firstPredicateKeywordList);
+        PhoneContainsKeywordsPredicate secondPredicate = new PhoneContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        PhoneContainsKeywordsPredicate firstPredicateCopy =
+                new PhoneContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_phoneContainsKeywords_returnsTrue() {
+        // One keyword
+        PhoneContainsKeywordsPredicate predicate =
+                new PhoneContainsKeywordsPredicate(Collections.singletonList("999555"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("999555").build()));
+
+        // Multiple keywords
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("999555", "555999"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("999555").build()));
+
+        // Only one matching keyword
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("111222", "222111"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("111222").build()));
+    }
+
+    @Test
+    public void test_phoneDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withPhone("999").build()));
+
+        // Non-matching keyword
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("555"));
+        assertFalse(predicate.test(new PersonBuilder().withPhone("999111").build()));
+
+        // Keywords match name, email, expected graduation year and address, but does not match phone
+        predicate = new PhoneContainsKeywordsPredicate(
+                Arrays.asList("Alice", "alice@email.com", "Main", "Street", "2020"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+                .withEmail("alice@email.com").withAddress("Main Street").withExpectedGraduationYear("2020").build()));
+    }
+}

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -6,6 +6,8 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
 import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
 
 import java.util.ArrayList;
@@ -111,24 +113,76 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find phone number of person in address book -> 0 persons found */
+        /* Case: find person with n/ prefix (only 1 name) -> 1 persons found */
+        command = FindCommand.COMMAND_WORD + " n/" + DANIEL.getName();
+        ModelHelper.setFilteredList(expectedModel, DANIEL);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find person with n/ prefix (>=2 names) -> 3 persons found */
+        command = FindCommand.COMMAND_WORD + " n/" + DANIEL.getName() + " " + BENSON.getName() + ELLE.getName();
+        ModelHelper.setFilteredList(expectedModel, DANIEL, BENSON, ELLE);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find person with n/ + p/ prefix (only 1 name) -> 1 persons found */
+        command = FindCommand.COMMAND_WORD + " n/" + DANIEL.getName() + " p/" + DANIEL.getPhone().value;
+        ModelHelper.setFilteredList(expectedModel, DANIEL);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find person with n/ + p/ prefix (>= 2 names and p/ matches 1 of the names) -> 1 persons found */
+        command = FindCommand.COMMAND_WORD + " n/" + DANIEL.getName() + " "
+                + BENSON.getName() + " " + ELLE.getName() + " p/" + DANIEL.getPhone().value;
+        ModelHelper.setFilteredList(expectedModel, DANIEL);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find person with n/ + p/ prefix (>= 2 names and p/ does not match any names) -> 0 persons found */
+        command = FindCommand.COMMAND_WORD + " n/" + DANIEL.getName() + " "
+                + BENSON.getName() + " " + ELLE.getName() + " p/" + GEORGE.getPhone().value;
+        ModelHelper.setFilteredList(expectedModel);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find person with n/ + p/ + e/ a/ + y/ prefix (1 value per field - all correct) -> 1 persons found */
+        command = FindCommand.COMMAND_WORD + " n/" + DANIEL.getName() + " " + " p/" + DANIEL.getPhone().value
+                + " e/" + DANIEL.getEmail().value + " a/" + DANIEL.getAddress().value
+                + " y/" + DANIEL.getExpectedGraduationYear().value;
+        ModelHelper.setFilteredList(expectedModel, DANIEL);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find person with n/ + p/ + e/ a/ + y/ prefix (1 value per field - one incorrect) -> 0 persons found */
+        command = FindCommand.COMMAND_WORD + " n/" + DANIEL.getName() + " " + " p/" + DANIEL.getPhone().value
+                + " e/" + DANIEL.getEmail().value + " a/" + DANIEL.getAddress().value
+                + " y/" + GEORGE.getExpectedGraduationYear().value;
+        ModelHelper.setFilteredList(expectedModel);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find phone number of person in address book -> 1 persons found */
         command = FindCommand.COMMAND_WORD + " " + DANIEL.getPhone().value;
+        ModelHelper.setFilteredList(expectedModel, DANIEL);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find address of person in address book -> 0 persons found */
+        /* Case: find address of person in address book -> 3 persons found */
         command = FindCommand.COMMAND_WORD + " " + DANIEL.getAddress().value;
+        ModelHelper.setFilteredList(expectedModel, DANIEL, CARL, GEORGE);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find email of person in address book -> 0 persons found */
+        /* Case: find email of person in address book -> 1 persons found */
         command = FindCommand.COMMAND_WORD + " " + DANIEL.getEmail().value;
+        ModelHelper.setFilteredList(expectedModel, DANIEL);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find tags of person in address book -> 0 persons found */
         List<Tag> tags = new ArrayList<>(DANIEL.getTags());
         command = FindCommand.COMMAND_WORD + " " + tags.get(0).tagName;
+        ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 


### PR DESCRIPTION
This PR does the following:

1. Improve `find` command to allow searching for **exact** keywords that extends to **all** fields. If the first keyword is not a prefix, this command would assume a global search for **all** fields.
E.g. 
`find alex lidavid@example.com 87438807` - displays a list of people with any of their fields matching the keyword `alex`,`lidavid@example.com` or `87438807`.

2. Improve `find` command to allow searching for **exact** keywords according to the **prefix supplied** by the user.
E.g.
`find n/alex bernice e/alexyeoh@example.com p/87438807` - displays a list of people whose `name` contains keyword `alex` **OR** `bernice` **AND** `email` contains keyword `alexyeoh@example.com` **AND** `phone` contains keyword `87438807`

3. Updated and added tests including:
-  Predicate tests
- AddressbookParserTest
- FindCommandTest
- FindCommandParserTest
- FindCommandSystemTest

4. Updated **message usage** for find command and User Guide.