### PR TITLE
Improved find command (exact keyword search)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -16,7 +16,7 @@ public class FindCommand extends Command {
             + "the specified keywords (case-sensitive) and displays them as a list with index numbers.\n"
             + "Option 1 (Search all fields): KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alex david alexyeoh@example.com\n\n"
-            + "Option 2 (Search by prefixs): /n[KEYWORD] [MORE_KEYWORDS] /p...\n"
+            + "Option 2 (Search by prefix): /n[KEYWORD] [MORE_KEYWORDS] /p...\n"
             + "Example: " + COMMAND_WORD + " n/Alex Bernice p/999 555";
 
     private final Predicate<Person> predicate;

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -4,24 +4,15 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPECTED_GRADUATION_YEAR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MAJOR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.AddressContainsKeywordsPredicate;
-import seedu.address.model.person.EmailContainsKeywordsPredicate;
-import seedu.address.model.person.ExpectedGraduationYearContainsKeywordsPredicate;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -44,94 +35,15 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_EXPECTED_GRADUATION_YEAR); // more fields to be added if necessary
-
-        List<Predicate<Person>> predicateList = new ArrayList<>();
-        Predicate<Person> finalPredicate;
-        boolean isGlobalSearch = false;
+                        PREFIX_EXPECTED_GRADUATION_YEAR, PREFIX_MAJOR); // more fields to be added if necessary
 
         try {
-            // no prefix used, search for all fields (global search)
-            if (!startWithPrefix(trimmedArgs)) {
-                isGlobalSearch = true;
-                String[] keywords = trimmedArgs.split("\\s+");
-
-                predicateList.add(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
-                predicateList.add(new PhoneContainsKeywordsPredicate(Arrays.asList(keywords)));
-                predicateList.add(new EmailContainsKeywordsPredicate(Arrays.asList(keywords)));
-                predicateList.add(new AddressContainsKeywordsPredicate(Arrays.asList(keywords)));
-                predicateList.add(new ExpectedGraduationYearContainsKeywordsPredicate(Arrays.asList(keywords)));
-
-                finalPredicate = combinePredicates(isGlobalSearch,
-                        predicateList.toArray(new Predicate[predicateList.size()]));
-                return new FindCommand(finalPredicate);
-            }
-
-            // at least one prefix is used, search for fields that matches prefix only
-            if (!argMultimap.getPreamble().isEmpty()) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-            }
-
-            // checks if prefix is present in argMultimap and adds the corresponding predicate to predicateList
-            if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-                String[] nameKeywords = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
-                predicateList.add(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
-            }
-            if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-                String[] phoneKeywords = argMultimap.getValue(PREFIX_PHONE).get().split("\\s+");
-                predicateList.add(new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeywords)));
-            }
-            if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-                String[] emailKeywords = argMultimap.getValue(PREFIX_EMAIL).get().split("\\s+");
-                predicateList.add(new EmailContainsKeywordsPredicate(Arrays.asList(emailKeywords)));
-            }
-            if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-                String[] addressKeywords = argMultimap.getValue(PREFIX_ADDRESS).get().split("\\s+");
-                predicateList.add(new AddressContainsKeywordsPredicate(Arrays.asList(addressKeywords)));
-            }
-            if (argMultimap.getValue(PREFIX_EXPECTED_GRADUATION_YEAR).isPresent()) {
-                String[] expectedGraduationYearKeywords =
-                        argMultimap.getValue(PREFIX_EXPECTED_GRADUATION_YEAR).get().split("\\s+");
-                predicateList.add(new ExpectedGraduationYearContainsKeywordsPredicate(
-                                  Arrays.asList(expectedGraduationYearKeywords)));
-            }
-
-            finalPredicate = combinePredicates(isGlobalSearch,
-                                               predicateList.toArray(new Predicate[predicateList.size()]));
+            Predicate<Person> finalPredicate = FindUtil.parseFindArgs(trimmedArgs, argMultimap);
             return new FindCommand(finalPredicate);
-        } catch (IllegalValueException ive) {
+        } catch (ParseException ive) {
             throw new ParseException(ive.getMessage(), ive);
         }
     }
 
-    /**
-     * Returns whether the user starts with a prefix in the argument as a boolean result.
-     */
-    private boolean startWithPrefix(String trimmedArgs) {
-        String[] args = trimmedArgs.split("\\s+");
 
-        return (args[0].contains(PREFIX_NAME.toString())
-                || args[0].contains(PREFIX_PHONE.toString())
-                || args[0].contains(PREFIX_EMAIL.toString())
-                || args[0].contains(PREFIX_ADDRESS.toString())
-                || args[0].contains(PREFIX_EXPECTED_GRADUATION_YEAR.toString()));
-    }
-
-    /**
-     * Combines all predicates in {@code predicateList} that matches the
-     * corresponding condition to form {@code finalPredicate}
-     * @param predicates in the form of varargs
-     * @return {@code finalPredicate} of type {@code Predicate<Person>}
-     */
-    private Predicate<Person> combinePredicates(boolean isGlobalSearch, Predicate<Person>... predicates) {
-        Predicate<Person> finalPredicate;
-
-        if (isGlobalSearch) {
-            finalPredicate = Stream.of(predicates).reduce(condition -> false, Predicate::or);
-        } else {
-            finalPredicate = Stream.of(predicates).reduce(condition -> true, Predicate::and);
-        }
-
-        return finalPredicate;
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/FindUtil.java
+++ b/src/main/java/seedu/address/logic/parser/FindUtil.java
@@ -1,0 +1,166 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPECTED_GRADUATION_YEAR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MAJOR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.ExpectedGraduationYearContainsKeywordsPredicate;
+import seedu.address.model.person.MajorContainsKeywordsPredicate;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+
+/**
+ * Contains utility methods used for FindCommandParser
+ */
+public class FindUtil {
+
+    /**
+     * Parses the string {@code trimmedArgs} and {@code argMultimap} to form a combined Predicate based on user request
+     * @param trimmedArgs,argMultimap
+     * @return the predicate user demanded
+     * @throws ParseException
+     */
+    @SuppressWarnings("unchecked")
+    public static Predicate<Person> parseFindArgs(String trimmedArgs, ArgumentMultimap argMultimap)
+            throws ParseException {
+        requireNonNull(trimmedArgs);
+        List<Predicate<Person>> predicateList = new ArrayList<>();
+        boolean isGlobalSearch = false;
+        Predicate<Person> finalPredicate;
+
+        // no prefix used, search for all fields (global search)
+        if (!startWithPrefix(trimmedArgs)) {
+            isGlobalSearch = true;
+            String[] keywords = trimmedArgs.split("\\s+");
+
+            predicateList = parseAllPredicates(keywords, predicateList);
+            finalPredicate = combinePredicates(isGlobalSearch,
+                    predicateList.toArray(new Predicate[predicateList.size()]));
+
+            return finalPredicate;
+        } else {
+            // at least one prefix is used, search for fields that matches prefix only
+            if (!argMultimap.getPreamble().isEmpty()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+
+            predicateList = parseSelectedPredicates(argMultimap, predicateList);
+            finalPredicate = combinePredicates(isGlobalSearch,
+                    predicateList.toArray(new Predicate[predicateList.size()]));
+
+            return finalPredicate;
+        }
+    }
+
+    /**
+     * Parses the string {@code trimmedArgs} and a returns a boolean value true if prefix is present
+     * @param trimmedArgs
+     * @return boolean value
+     */
+    private static boolean startWithPrefix(String trimmedArgs) {
+        String[] args = trimmedArgs.split("\\s+");
+
+        return (args[0].contains(PREFIX_NAME.toString())
+                || args[0].contains(PREFIX_PHONE.toString())
+                || args[0].contains(PREFIX_EMAIL.toString())
+                || args[0].contains(PREFIX_ADDRESS.toString())
+                || args[0].contains(PREFIX_EXPECTED_GRADUATION_YEAR.toString())
+                || args[0].contains(PREFIX_MAJOR.toString()));
+    }
+
+    /**
+     * Parses the String array {@code trimmedArgs} and {@code predicateList} to
+     * form a combined Predicate based on user request
+     * @param keywords,predicateList
+     * @return a list of Predicate
+     */
+    private static List<Predicate<Person>> parseAllPredicates(String[] keywords,
+                                                              List<Predicate<Person>> predicateList) {
+        predicateList.add(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        predicateList.add(new PhoneContainsKeywordsPredicate(Arrays.asList(keywords)));
+        predicateList.add(new EmailContainsKeywordsPredicate(Arrays.asList(keywords)));
+        predicateList.add(new AddressContainsKeywordsPredicate(Arrays.asList(keywords)));
+        predicateList.add(new ExpectedGraduationYearContainsKeywordsPredicate(Arrays.asList(keywords)));
+        predicateList.add(new MajorContainsKeywordsPredicate(Arrays.asList(keywords)));
+
+        return predicateList;
+    }
+
+    /**
+     * Parses the ArgumentMultimap {@code argMultimap} and {@code predicateList} to
+     * form a combined Predicate based on user request
+     * @param argMultimap,predicateList
+     * @return a list of Predicate
+     */
+    private static List<Predicate<Person>> parseSelectedPredicates(
+            ArgumentMultimap argMultimap, List<Predicate<Person>> predicateList) {
+
+        // checks if prefix is present in argMultimap and adds the corresponding predicate to predicateList
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            String[] nameKeywords = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
+            predicateList.add(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            String[] phoneKeywords = argMultimap.getValue(PREFIX_PHONE).get().split("\\s+");
+            predicateList.add(new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            String[] emailKeywords = argMultimap.getValue(PREFIX_EMAIL).get().split("\\s+");
+            predicateList.add(new EmailContainsKeywordsPredicate(Arrays.asList(emailKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
+            String[] addressKeywords = argMultimap.getValue(PREFIX_ADDRESS).get().split("\\s+");
+            predicateList.add(new AddressContainsKeywordsPredicate(Arrays.asList(addressKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_EXPECTED_GRADUATION_YEAR).isPresent()) {
+            String[] expectedGraduationYearKeywords =
+                    argMultimap.getValue(PREFIX_EXPECTED_GRADUATION_YEAR).get().split("\\s+");
+            predicateList.add(new ExpectedGraduationYearContainsKeywordsPredicate(
+                    Arrays.asList(expectedGraduationYearKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_MAJOR).isPresent()) {
+            String[] majorKeywords =
+                    argMultimap.getValue(PREFIX_MAJOR).get().split("\\s+");
+            predicateList.add(new MajorContainsKeywordsPredicate(
+                    Arrays.asList(majorKeywords)));
+        }
+
+        return predicateList;
+    }
+
+    /**
+     * Combines all predicates in {@code predicateList} that matches the
+     * corresponding condition to form {@code finalPredicate}
+     * @param predicates in the form of varargs
+     * @return {@code finalPredicate} of type {@code Predicate<Person>}
+     */
+    @SuppressWarnings("unchecked")
+    private static Predicate<Person> combinePredicates(
+            boolean isGlobalSearch, Predicate<Person>... predicates) {
+        Predicate<Person> finalPredicate;
+
+        if (isGlobalSearch) {
+            finalPredicate = Stream.of(predicates).reduce(condition -> false, Predicate::or);
+        } else {
+            finalPredicate = Stream.of(predicates).reduce(condition -> true, Predicate::and);
+        }
+
+        return finalPredicate;
+    }
+}

--- a/src/main/java/seedu/address/model/person/MajorContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/MajorContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Major} matches any of the keywords given.
+ */
+public class MajorContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public MajorContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getMajor().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof MajorContainsKeywordsPredicate // instanceof handles nulls
+                && this.keywords.equals(((MajorContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -32,7 +32,8 @@ public class Person {
      */
     public Person(Name name, Phone phone, Email email, Address address, ExpectedGraduationYear expectedGraduationYear,
                   Major major, Rating rating, Resume resume, InterviewDate interviewDate, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, expectedGraduationYear, rating, resume, interviewDate, tags);
+        requireAllNonNull(name, phone, email, address, expectedGraduationYear,
+                major, rating, resume, interviewDate, tags);
 
         this.name = name;
         this.phone = phone;

--- a/src/test/java/seedu/address/model/person/MajorContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/MajorContainsKeywordsPredicateTest.java
@@ -35,7 +35,7 @@ public class MajorContainsKeywordsPredicateTest {
         assertFalse(firstPredicate.equals(1));
 
         // null -> returns false
-        assertFalse(firstPredicate.equals(null));
+        assertFalse(firstPredicate == null));
 
         // different person -> returns false
         assertFalse(firstPredicate.equals(secondPredicate));

--- a/src/test/java/seedu/address/model/person/MajorContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/MajorContainsKeywordsPredicateTest.java
@@ -35,7 +35,7 @@ public class MajorContainsKeywordsPredicateTest {
         assertFalse(firstPredicate.equals(1));
 
         // null -> returns false
-        assertFalse(firstPredicate == null));
+        assertFalse(firstPredicate == null);
 
         // different person -> returns false
         assertFalse(firstPredicate.equals(secondPredicate));

--- a/src/test/java/seedu/address/model/person/MajorContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/MajorContainsKeywordsPredicateTest.java
@@ -1,0 +1,81 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class MajorContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("Computer");
+        List<String> secondPredicateKeywordList = Arrays.asList("Computer", "Science");
+
+        MajorContainsKeywordsPredicate firstPredicate =
+                new MajorContainsKeywordsPredicate(firstPredicateKeywordList);
+        MajorContainsKeywordsPredicate secondPredicate =
+                new MajorContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        MajorContainsKeywordsPredicate firstPredicateCopy =
+                new MajorContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_majorContainsKeywords_returnsTrue() {
+        // One keyword
+        MajorContainsKeywordsPredicate predicate =
+                new MajorContainsKeywordsPredicate(Collections.singletonList("Computer"));
+        assertTrue(predicate.test(new PersonBuilder().withMajor("Computer Science").build()));
+
+        // Multiple keywords
+        predicate = new MajorContainsKeywordsPredicate(Arrays.asList("Computer", "Science"));
+        assertTrue(predicate.test(new PersonBuilder().withMajor("Computer Science").build()));
+
+        // Only one matching keyword
+        predicate = new MajorContainsKeywordsPredicate(Arrays.asList("Computer", "Engineering"));
+        assertTrue(predicate.test(new PersonBuilder().withMajor("Computer Science").build()));
+
+        // Mixed-case keywords
+        predicate = new MajorContainsKeywordsPredicate(Arrays.asList("ComPutEr", "SciEncE"));
+        assertTrue(predicate.test(new PersonBuilder().withMajor("Computer Science").build()));
+    }
+
+    @Test
+    public void test_majorDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        MajorContainsKeywordsPredicate predicate = new MajorContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withMajor("Computer Science").build()));
+
+        // Non-matching keyword
+        predicate = new MajorContainsKeywordsPredicate(Arrays.asList("Security"));
+        assertFalse(predicate.test(new PersonBuilder().withMajor("Computer Science").build()));
+
+        // Keywords match phone, email, expected graduation year and address, but does not match major
+        predicate = new MajorContainsKeywordsPredicate(
+                Arrays.asList("12345", "alice@email.com", "Main", "Street", "2020", "Information", "Security"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+                .withEmail("alice@email.com").withAddress("Main Street").withExpectedGraduationYear("2020")
+                .withMajor("Computer Science").build()));
+    }
+}


### PR DESCRIPTION
Fixes #30.

This PR is a continuation of #16. It does the following:
1) Added new predicate and predicate test for field `major`.
2) Refactored methods in `FindCommandParser` to `FindUtil`.

Reminder to self: Update and check tests comprehensively once all new fields are added in.

Would love to request for quality checks! @kowshik-sundararajan 

Points to seek clarification:
1) I plan to add more predicates so `FindUtil` would get significantly larger. Any advice to cope with this issue? Does it make sense to have a Predicate class to store all the predicates and provide methods for processing when needed?

2) I am passing an array of `List<Predicate<Person>>` to the `combinePredicates` method in `FindUtil.java` as varargs of `Predicate<Person>`. Refer to this piece of code in `FindUtil.java`:

```
finalPredicate = combinePredicates(isGlobalSearch, predicateList.toArray(new Predicate[predicateList.size()]));
```
It gives a warning: `Unchecked assignment: 'java.util.function.Predicate' to 'java.util.function.Predicate<seedu.address.model.person.Person>` since I am passing a `Predicate` array to a method that accepts `Predicate<Person>`.

I am currently suppressing this warning since this method is contained within internal use and not exposed to user input. May I ask if this is considered a bad practice?
