### PR TITLE
Add status field and status command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -40,7 +40,8 @@ public class AddCommand extends UndoableCommand {
             + PREFIX_MAJOR + "Computer Science "
             + PREFIX_RESUME + "jdoe.pdf "
             + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_TAG + "owesMoney\n"
+            + "The status is initialised to be 'new'.";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/DeleteRatingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteRatingCommand.java
@@ -20,6 +20,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Rating;
 import seedu.address.model.person.Resume;
+import seedu.address.model.person.Status;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.tag.Tag;
@@ -99,10 +100,11 @@ public class DeleteRatingCommand extends UndoableCommand {
                 Rating.DEFAULT_SCORE, Rating.DEFAULT_SCORE);
         Resume resume = targetPerson.getResume();
         InterviewDate interviewDate = targetPerson.getInterviewDate();
+        Status status = targetPerson.getStatus();
         Set<Tag> tags = targetPerson.getTags();
 
         return new Person(name, phone, email, address,
-                expectedGraduationYear, major, defaultRating, resume, interviewDate, tags);
+                expectedGraduationYear, major, defaultRating, resume, interviewDate, status, tags);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -136,7 +136,7 @@ public class EditCommand extends UndoableCommand {
 
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,updatedExpectedGraduationYear,
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedExpectedGraduationYear,
                 updatedMajor, rating, updatedResume, interviewDate, status, updatedTags);
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -32,6 +32,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Rating;
 import seedu.address.model.person.Resume;
+import seedu.address.model.person.Status;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.tag.Tag;
@@ -124,15 +125,19 @@ public class EditCommand extends UndoableCommand {
 
         // Doesn't allow editing of rating
         Rating rating = personToEdit.getRating();
+
         Resume updatedResume = editPersonDescriptor.getResume().orElse(personToEdit.getResume());
 
         // Doesn't allow editing of interview date
         InterviewDate interviewDate = personToEdit.getInterviewDate();
 
+        // Doesn't allow editing of status
+        Status status = personToEdit.getStatus();
+
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,
-                updatedExpectedGraduationYear, updatedMajor, rating, updatedResume, interviewDate, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,updatedExpectedGraduationYear,
+                updatedMajor, rating, updatedResume, interviewDate, status, updatedTags);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/InterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InterviewCommand.java
@@ -99,7 +99,7 @@ public class InterviewCommand extends UndoableCommand {
 
         return new Person(personToInterview.getName(), personToInterview.getPhone(), personToInterview.getEmail(),
                 personToInterview.getAddress(), personToInterview.getExpectedGraduationYear(),
-                personToInterview.getMajor(),personToInterview.getRating(), personToInterview.getResume(),
+                personToInterview.getMajor(), personToInterview.getRating(), personToInterview.getResume(),
                 new InterviewDate(dateTime), personToInterview.getStatus(), personToInterview.getTags());
     }
 

--- a/src/main/java/seedu/address/logic/commands/InterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InterviewCommand.java
@@ -99,9 +99,8 @@ public class InterviewCommand extends UndoableCommand {
 
         return new Person(personToInterview.getName(), personToInterview.getPhone(), personToInterview.getEmail(),
                 personToInterview.getAddress(), personToInterview.getExpectedGraduationYear(),
-                personToInterview.getMajor(),
-                personToInterview.getRating(), personToInterview.getResume(), new InterviewDate(dateTime),
-                personToInterview.getTags());
+                personToInterview.getMajor(),personToInterview.getRating(), personToInterview.getResume(),
+                new InterviewDate(dateTime), personToInterview.getStatus(), personToInterview.getTags());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/RateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RateCommand.java
@@ -100,7 +100,8 @@ public class RateCommand extends UndoableCommand {
 
         return new Person(personToRate.getName(), personToRate.getPhone(), personToRate.getEmail(),
                 personToRate.getAddress(), personToRate.getExpectedGraduationYear(), personToRate.getMajor(), rating,
-                personToRate.getResume(), personToRate.getInterviewDate(), personToRate.getTags());
+                personToRate.getResume(), personToRate.getInterviewDate(), personToRate.getStatus(),
+                personToRate.getTags());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/StatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatusCommand.java
@@ -1,0 +1,129 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.List;
+import java.util.Objects;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Status;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+
+/**
+ * Update status of an existing person in HR+.
+ */
+public class StatusCommand extends UndoableCommand {
+    public static final String COMMAND_WORD = "status";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Update status for the person "
+            + "by the index number used in the last person listing. "
+            + "Existing status will be overwritten by the input value.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "STATUS_INDEX(by the list below)\n"
+            + "1. new\n"
+            + "2. interview first round\n"
+            + "3. interview second round\n"
+            + "4. rejected\n"
+            + "5. on waitlist\n"
+            + "6. position offered\n"
+            + "7. offer accepted\n"
+            + "Example: " + COMMAND_WORD + " 1 2";
+
+    public static final String MESSAGE_STATUS_SUCCESS =
+            "Status of person named %1$s has been updated tp '%2$s'";
+
+    private final Index index;
+    private final Status updatedStatus;
+
+    private Person personToUpdateStatus;
+    private Person updatedPerson;
+
+    /**
+     * @param index of the person in the filtered person list to update status
+     * @param updatedStatus updatedStatus
+     */
+    public StatusCommand(Index index, Status updatedStatus) {
+        requireNonNull(index);
+        requireNonNull(updatedStatus);
+
+        this.index    = index;
+        this.updatedStatus = updatedStatus;
+    }
+
+    public Index getIndex() {
+        return index;
+    }
+
+    public Status getUpdatedStatus() {
+        return updatedStatus;
+    }
+
+    public Person getPersonToUpdateStatus() {
+        return personToUpdateStatus;
+    }
+
+    @Override
+    public CommandResult executeUndoableCommand() {
+        try {
+            model.updatePerson(personToUpdateStatus, updatedPerson);
+        } catch (DuplicatePersonException dpe) {
+            throw new AssertionError("The target person cannot become a duplicate of another person "
+                    + "via updating status");
+        } catch (PersonNotFoundException pnfe) {
+            throw new AssertionError("The target person cannot be missing");
+        }
+
+        return new CommandResult(String.format(MESSAGE_STATUS_SUCCESS,
+                updatedPerson.getName(), updatedStatus.value));
+    }
+
+    @Override
+    protected void preprocessUndoableCommand() throws CommandException {
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        personToUpdateStatus = lastShownList.get(index.getZeroBased());
+        updatedPerson = createUpdatedPerson(personToUpdateStatus, updatedStatus);
+    }
+
+    /**
+     * Creates and returns a {@code Person} with the details of {@code personToUpdateStatus}
+     * with updated with {@code statusIndex}.
+     */
+    private static Person createUpdatedPerson(Person personToUpdateStatus, Status updatedStatus) {
+        requireAllNonNull(personToUpdateStatus);
+
+        return new Person(personToUpdateStatus.getName(), personToUpdateStatus.getPhone(),
+                personToUpdateStatus.getEmail(), personToUpdateStatus.getAddress(),
+                personToUpdateStatus.getExpectedGraduationYear(), personToUpdateStatus.getMajor(),
+                personToUpdateStatus.getRating(), personToUpdateStatus.getResume(),
+                personToUpdateStatus.getInterviewDate(), updatedStatus, personToUpdateStatus.getTags());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // Short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof StatusCommand)) {
+            return false;
+        }
+
+        // State check
+        StatusCommand i = (StatusCommand) other;
+        return getIndex().equals(i.getIndex())
+                && getUpdatedStatus().equals(i.getUpdatedStatus())
+                && Objects.equals(getPersonToUpdateStatus(), i.getPersonToUpdateStatus());
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/StatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatusCommand.java
@@ -25,17 +25,18 @@ public class StatusCommand extends UndoableCommand {
             + "Existing status will be overwritten by the input value.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "STATUS_INDEX(by the list below)\n"
-            + "1. new\n"
-            + "2. interview first round\n"
-            + "3. interview second round\n"
-            + "4. rejected\n"
-            + "5. on waitlist\n"
-            + "6. position offered\n"
-            + "7. offer accepted\n"
+            + "1. " + Status.STATUS_NEW + "\n"
+            + "2. " + Status.STATUS_INTERVIEW_FIRST_ROUND + "\n"
+            + "3. " + Status.STATUS_INTERVIEW_SECOND_ROUND + "\n"
+            + "4. " + Status.STATUS_REJECTED + "\n"
+            + "5. " + Status.STATUS_WAITLIST + "\n"
+            + "6. " + Status.STATUS_OFFERED + "\n"
+            + "7. " + Status.STATUS_ACCEPTED + "\n"
+            + "8. " + Status.STATUS_WITHDRAWN + "\n"
             + "Example: " + COMMAND_WORD + " 1 2";
 
     public static final String MESSAGE_STATUS_SUCCESS =
-            "Status of person named %1$s has been updated tp '%2$s'";
+            "Status of person named %1$s has been updated to '%2$s'";
 
     private final Index index;
     private final Status updatedStatus;
@@ -73,9 +74,9 @@ public class StatusCommand extends UndoableCommand {
             model.updatePerson(personToUpdateStatus, updatedPerson);
         } catch (DuplicatePersonException dpe) {
             throw new AssertionError("The target person cannot become a duplicate of another person "
-                    + "via updating status");
+                    + "via updating status.");
         } catch (PersonNotFoundException pnfe) {
-            throw new AssertionError("The target person cannot be missing");
+            throw new AssertionError("The target person cannot be missing.");
         }
 
         return new CommandResult(String.format(MESSAGE_STATUS_SUCCESS,

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -27,6 +27,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Rating;
 import seedu.address.model.person.Resume;
+import seedu.address.model.person.Status;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -60,22 +61,21 @@ public class AddCommandParser implements Parser<AddCommand> {
                     .getValue(PREFIX_EXPECTED_GRADUATION_YEAR)).get();
             Major major = ParserUtil.parseMajor(argMultimap.getValue(PREFIX_MAJOR)).get();
 
-            // Add command does not allow adding rating straight away
-            Rating rating = new Rating(Rating.DEFAULT_SCORE, Rating.DEFAULT_SCORE,
-                    Rating.DEFAULT_SCORE, Rating.DEFAULT_SCORE);
-
             // Optional fields
             Optional<Resume> resumeOptional = ParserUtil.parseResume(argMultimap.getValue(PREFIX_RESUME));
             Resume resume = resumeOptional.isPresent() ? resumeOptional.get() : new Resume(null);
 
-            // Fixed fields
+            // Default-valued fields
+            Rating rating = new Rating(Rating.DEFAULT_SCORE, Rating.DEFAULT_SCORE,
+                    Rating.DEFAULT_SCORE, Rating.DEFAULT_SCORE);
             InterviewDate interviewDate = new InterviewDate();
+            Status status = new Status();
 
             // Other fields
             Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
             Person person = new Person(name, phone, email, address, expectedGraduationYear,
-                    major, rating, resume, interviewDate, tagList);
+                    major, rating, resume, interviewDate, status, tagList);
             return new AddCommand(person);
 
         } catch (IllegalValueException ive) {

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RateCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.StatusCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -99,6 +100,9 @@ public class AddressBookParser {
 
         case DeleteRatingCommand.COMMAND_WORD:
             return new DeleteRatingCommandParser().parse(arguments);
+
+        case StatusCommand.COMMAND_WORD:
+            return new StatusCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/StatusCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StatusCommandParser.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.StatusCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Status;
+/**
+ * Parses input arguments and creates a new StatusCommand object
+ */
+public class StatusCommandParser implements Parser<StatusCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the StatusCommand
+     * and returns an StatusCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public StatusCommand parse(String args) throws ParseException {
+        try {
+            // Parse the arguments
+            String[] arguments = args.trim().split("\\s+", 2);
+            if (arguments.length != 2) {
+                throw new IllegalValueException("Invalid command, expected 2 arguments");
+            }
+            // Parse the index
+            Index index = ParserUtil.parseIndex(arguments[0]);
+
+            // Parse the status
+            int statusIndex = Integer.valueOf(arguments[1]);
+            Status status = null;
+            if (Status.isValidStatus(statusIndex)) {
+                status = new Status(statusIndex);
+            } else {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, StatusCommand.MESSAGE_USAGE));
+            }
+
+            return new StatusCommand(index, status);
+
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, StatusCommand.MESSAGE_USAGE));
+        } catch (ParseException pe) {
+            throw pe;
+
+        } catch (IllegalValueException ive) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, StatusCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -135,7 +135,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         return new Person(
                 person.getName(), person.getPhone(), person.getEmail(), person.getAddress(),
                 person.getExpectedGraduationYear(), person.getMajor(), person.getRating(), person.getResume(),
-                person.getInterviewDate(), correctTagReferences);
+                person.getInterviewDate(), person.getStatus(), correctTagReferences);
     }
 
     /**
@@ -177,9 +177,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     private void removeTagFromEachPerson(Person person, Tag tag) {
         Set<Tag> editedTags = new HashSet<>(person.getTags());
         if (editedTags.remove(tag)) {
-            Person editedPerson = new Person(person.getName(), person.getPhone(),
-                    person.getEmail(), person.getAddress(), person.getExpectedGraduationYear(),
-                    person.getMajor(), person.getRating(), person.getResume(), person.getInterviewDate(), editedTags);
+            Person editedPerson = new Person(person.getName(), person.getPhone(),person.getEmail(),
+                    person.getAddress(), person.getExpectedGraduationYear(), person.getMajor(), person.getRating(),
+                    person.getResume(), person.getInterviewDate(), person.getStatus(), editedTags);
             try {
                 updatePerson(person, editedPerson);
             } catch (DuplicatePersonException dpe) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -177,7 +177,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     private void removeTagFromEachPerson(Person person, Tag tag) {
         Set<Tag> editedTags = new HashSet<>(person.getTags());
         if (editedTags.remove(tag)) {
-            Person editedPerson = new Person(person.getName(), person.getPhone(),person.getEmail(),
+            Person editedPerson = new Person(person.getName(), person.getPhone(), person.getEmail(),
                     person.getAddress(), person.getExpectedGraduationYear(), person.getMajor(), person.getRating(),
                     person.getResume(), person.getInterviewDate(), person.getStatus(), editedTags);
             try {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -24,6 +24,7 @@ public class Person {
     private final Rating rating;
     private final Resume resume;
     private final InterviewDate interviewDate;
+    private final Status status;
 
     private final UniqueTagList tags;
 
@@ -31,9 +32,10 @@ public class Person {
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, ExpectedGraduationYear expectedGraduationYear,
-                  Major major, Rating rating, Resume resume, InterviewDate interviewDate, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, expectedGraduationYear,
-                major, rating, resume, interviewDate, tags);
+                  Major major, Rating rating, Resume resume, InterviewDate interviewDate, Status status,
+                  Set<Tag> tags) {
+        requireAllNonNull(name, phone, email, address, expectedGraduationYear, major, rating, resume, interviewDate,
+                status, tags);
 
         this.name = name;
         this.phone = phone;
@@ -44,6 +46,7 @@ public class Person {
         this.rating = rating;
         this.resume = resume;
         this.interviewDate = interviewDate;
+        this.status = status;
         // protect internal tags from changes in the arg list
         this.tags = new UniqueTagList(tags);
     }
@@ -84,6 +87,10 @@ public class Person {
         return interviewDate;
     }
 
+    public Status getStatus() {
+        return status;
+    }
+
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
@@ -116,7 +123,7 @@ public class Person {
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
         return Objects.hash(name, phone, email, address, expectedGraduationYear,
-                major, rating, resume, interviewDate, tags);
+                major, rating, resume, interviewDate, status, tags);
     }
 
     @Override
@@ -135,6 +142,8 @@ public class Person {
                 .append(getMajor())
                 .append(" Resume: ")
                 .append(getResume())
+                .append(" Status: ")
+                .append(getStatus())
                 .append(" Tags: ");
         getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/seedu/address/model/person/Status.java
+++ b/src/main/java/seedu/address/model/person/Status.java
@@ -15,47 +15,54 @@ public class Status {
 
     public static final String MESSAGE_STATUS_CONSTRAINTS =
             "Person status should only be specified by one of the predefined status indices.";
-    private static final String STATUS_NEW = "new";
-    private static final String STATUS_INTERVIEW_FIRST_ROUND = "interview first round";
-    private static final String STATUS_INTERVIEW_SECOND_ROUND = "interview second round";
-    private static final String STATUS_REJECTED = "rejected";
-    private static final String STATUS_WAITLIST = "on waitlist";
-    private static final String STATUS_OFFERED = "position offered";
-    private static final String STATUS_ACCEPTED = "offer accepted";
+    public static final String STATUS_NEW = "New";
+    public static final String STATUS_INTERVIEW_FIRST_ROUND = "1st round";
+    public static final String STATUS_INTERVIEW_SECOND_ROUND = "2nd round";
+    public static final String STATUS_REJECTED = "Rejected";
+    public static final String STATUS_WAITLIST = "Waitlist";
+    public static final String STATUS_OFFERED = "Offered";
+    public static final String STATUS_ACCEPTED = "Accepted";
+    public static final String STATUS_WITHDRAWN = "Withdrawn";
 
-    private static final int INDEX_STATUS_NEW = 1;
-    private static final int INDEX_STATUS_INTERVIEW_FIRST_ROUND = 2;
-    private static final int INDEX_STATUS_INTERVIEW_SECOND_ROUND = 3;
-    private static final int INDEX_STATUS_REJECTED = 4;
-    private static final int INDEX_STATUS_WAITLIST = 5;
-    private static final int INDEX_STATUS_OFFERED = 6;
-    private static final int INDEX_STATUS_ACCEPTED = 7;
+    public static final int STATUS_TYPE_CONUT = 8;
 
-    private static final Color COLOR_NEW = Color.GREY;
-    private static final Color COLOR_INTERVIEW_FIRST_ROUND = Color.YELLOW;
-    private static final Color COLOR_INTERVIEW_SECOND_ROUND = Color.ORANGE;
-    private static final Color COLOR_REJECTED = Color.RED;
-    private static final Color COLOR_WAITLIST = Color.BROWN;
-    private static final Color COLOR_OFFERED = Color.CYAN;
-    private static final Color COLOR_ACCEPTED = Color.GREEN;
+    public static final int INDEX_STATUS_NEW = 1;
+    public static final int INDEX_STATUS_INTERVIEW_FIRST_ROUND = 2;
+    public static final int INDEX_STATUS_INTERVIEW_SECOND_ROUND = 3;
+    public static final int INDEX_STATUS_REJECTED = 4;
+    public static final int INDEX_STATUS_WAITLIST = 5;
+    public static final int INDEX_STATUS_OFFERED = 6;
+    public static final int INDEX_STATUS_ACCEPTED = 7;
+    public static final int INDEX_STATUS_WITHDRAWN = 8;
 
-    private static final HashMap<Integer, String> statusMap = new HashMap<Integer, String>() {{
+    public static final Color COLOR_NEW = Color.GREY;
+    public static final Color COLOR_INTERVIEW_FIRST_ROUND = Color.YELLOW;
+    public static final Color COLOR_INTERVIEW_SECOND_ROUND = Color.ORANGE;
+    public static final Color COLOR_REJECTED = Color.RED;
+    public static final Color COLOR_WAITLIST = Color.BROWN;
+    public static final Color COLOR_OFFERED = Color.CYAN;
+    public static final Color COLOR_ACCEPTED = Color.GREEN;
+    public static final Color COLOR_WITHDRAWN = Color.PURPLE;
+
+    private static final HashMap<Integer, String> STATUS_MAP = new HashMap<Integer, String>() {{
             put(INDEX_STATUS_NEW, STATUS_NEW);
             put(INDEX_STATUS_INTERVIEW_FIRST_ROUND, STATUS_INTERVIEW_FIRST_ROUND);
             put(INDEX_STATUS_INTERVIEW_SECOND_ROUND, STATUS_INTERVIEW_SECOND_ROUND);
             put(INDEX_STATUS_REJECTED, STATUS_REJECTED);
             put(INDEX_STATUS_WAITLIST, STATUS_WAITLIST);
             put(INDEX_STATUS_OFFERED, STATUS_OFFERED);
-            put(INDEX_STATUS_ACCEPTED, STATUS_ACCEPTED); }};
+            put(INDEX_STATUS_ACCEPTED, STATUS_ACCEPTED);
+            put(INDEX_STATUS_WITHDRAWN, STATUS_WITHDRAWN); }};
 
-    private static final HashMap<String, Color> colorMap = new HashMap<String, Color>() {{
+    private static final HashMap<String, Color> COLOR_MAP = new HashMap<String, Color>() {{
             put(STATUS_NEW, COLOR_NEW);
             put(STATUS_INTERVIEW_FIRST_ROUND, COLOR_INTERVIEW_FIRST_ROUND);
             put(STATUS_INTERVIEW_SECOND_ROUND, COLOR_INTERVIEW_SECOND_ROUND);
             put(STATUS_REJECTED, COLOR_REJECTED);
             put(STATUS_WAITLIST, COLOR_WAITLIST);
             put(STATUS_OFFERED, COLOR_OFFERED);
-            put(STATUS_ACCEPTED, COLOR_ACCEPTED); }};
+            put(STATUS_ACCEPTED, COLOR_ACCEPTED);
+            put(STATUS_WITHDRAWN, COLOR_WITHDRAWN); }};
 
     public final String value;
     public final Color color;
@@ -87,19 +94,19 @@ public class Status {
      * Returns true if a given string is a valid person major.
      */
     public static boolean isValidStatus (int test) {
-        return statusMap.containsKey(test);
+        return STATUS_MAP.containsKey(test);
     }
 
     public static boolean isValidXmlStatus(String test) {
-        return colorMap.containsKey(test);
+        return COLOR_MAP.containsKey(test);
     }
 
     private static String getStatus(int statusIndex) {
-        return statusMap.get(statusIndex);
+        return STATUS_MAP.get(statusIndex);
     }
 
     private static Color getColor(String status) {
-        return colorMap.get(status);
+        return COLOR_MAP.get(status);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Status.java
+++ b/src/main/java/seedu/address/model/person/Status.java
@@ -23,13 +23,13 @@ public class Status {
     private static final String STATUS_OFFERED = "position offered";
     private static final String STATUS_ACCEPTED = "offer accepted";
 
-    private static final String INDEX_STATUS_NEW = "1";
-    private static final String INDEX_STATUS_INTERVIEW_FIRST_ROUND = "2";
-    private static final String INDEX_STATUS_INTERVIEW_SECOND_ROUND = "3";
-    private static final String INDEX_STATUS_REJECTED = "4";
-    private static final String INDEX_STATUS_WAITLIST = "5";
-    private static final String INDEX_STATUS_OFFERED = "6";
-    private static final String INDEX_STATUS_ACCEPTED = "7";
+    private static final int INDEX_STATUS_NEW = 1;
+    private static final int INDEX_STATUS_INTERVIEW_FIRST_ROUND = 2;
+    private static final int INDEX_STATUS_INTERVIEW_SECOND_ROUND = 3;
+    private static final int INDEX_STATUS_REJECTED = 4;
+    private static final int INDEX_STATUS_WAITLIST = 5;
+    private static final int INDEX_STATUS_OFFERED = 6;
+    private static final int INDEX_STATUS_ACCEPTED = 7;
 
     private static final Color COLOR_NEW = Color.GREY;
     private static final Color COLOR_INTERVIEW_FIRST_ROUND = Color.YELLOW;
@@ -39,7 +39,7 @@ public class Status {
     private static final Color COLOR_OFFERED = Color.CYAN;
     private static final Color COLOR_ACCEPTED = Color.GREEN;
 
-    private static final HashMap<String, String> statusMap = new HashMap<String, String>() {{
+    private static final HashMap<Integer, String> statusMap = new HashMap<Integer, String>() {{
             put(INDEX_STATUS_NEW, STATUS_NEW);
             put(INDEX_STATUS_INTERVIEW_FIRST_ROUND, STATUS_INTERVIEW_FIRST_ROUND);
             put(INDEX_STATUS_INTERVIEW_SECOND_ROUND, STATUS_INTERVIEW_SECOND_ROUND);
@@ -65,23 +65,37 @@ public class Status {
      *
      * @param statusIndex A valid status index.
      */
-    public Status(String statusIndex) {
-        requireNonNull(statusIndex);
-        String trimmedStatusIndex = statusIndex.trim();
-        checkArgument(isValidStatus(trimmedStatusIndex), MESSAGE_STATUS_CONSTRAINTS);
-        this.value = getStatus(trimmedStatusIndex);
+    public Status(int statusIndex) {
+        checkArgument(isValidStatus(statusIndex), MESSAGE_STATUS_CONSTRAINTS);
+        this.value = getStatus(statusIndex);
+        this.color = getColor(value);
+    }
+
+    public Status(String status) {
+        requireNonNull(status);
+        checkArgument(isValidXmlStatus(status), MESSAGE_STATUS_CONSTRAINTS);
+        this.value = status;
+        this.color = getColor(value);
+    }
+
+    public Status() {
+        this.value = getStatus(INDEX_STATUS_NEW);
         this.color = getColor(value);
     }
 
     /**
      * Returns true if a given string is a valid person major.
      */
-    public static boolean isValidStatus(String test) {
+    public static boolean isValidStatus (int test) {
         return statusMap.containsKey(test);
     }
 
-    private static String getStatus(String trimmedStatusIndex) {
-        return statusMap.get(trimmedStatusIndex);
+    public static boolean isValidXmlStatus(String test) {
+        return colorMap.containsKey(test);
+    }
+
+    private static String getStatus(int statusIndex) {
+        return statusMap.get(statusIndex);
     }
 
     private static Color getColor(String status) {
@@ -96,7 +110,7 @@ public class Status {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof Major // instanceof handles nulls
+                || (other instanceof Status // instanceof handles nulls
                 && this.value.equals(((Status) other).value)); // state check
     }
 

--- a/src/main/java/seedu/address/model/person/Status.java
+++ b/src/main/java/seedu/address/model/person/Status.java
@@ -1,0 +1,107 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.util.HashMap;
+
+import javafx.scene.paint.Color;
+
+/**
+ * Represents a candidate's status of his/her application.
+ * Guarantees: Status value is one of the seven predefined values.
+ */
+public class Status {
+
+    public static final String MESSAGE_STATUS_CONSTRAINTS =
+            "Person status should only be specified by one of the predefined status indices.";
+    private static final String STATUS_NEW = "new";
+    private static final String STATUS_INTERVIEW_FIRST_ROUND = "interview first round";
+    private static final String STATUS_INTERVIEW_SECOND_ROUND = "interview second round";
+    private static final String STATUS_REJECTED = "rejected";
+    private static final String STATUS_WAITLIST = "on waitlist";
+    private static final String STATUS_OFFERED = "position offered";
+    private static final String STATUS_ACCEPTED = "offer accepted";
+
+    private static final String INDEX_STATUS_NEW = "1";
+    private static final String INDEX_STATUS_INTERVIEW_FIRST_ROUND = "2";
+    private static final String INDEX_STATUS_INTERVIEW_SECOND_ROUND = "3";
+    private static final String INDEX_STATUS_REJECTED = "4";
+    private static final String INDEX_STATUS_WAITLIST = "5";
+    private static final String INDEX_STATUS_OFFERED = "6";
+    private static final String INDEX_STATUS_ACCEPTED = "7";
+
+    private static final Color COLOR_NEW = Color.GREY;
+    private static final Color COLOR_INTERVIEW_FIRST_ROUND = Color.YELLOW;
+    private static final Color COLOR_INTERVIEW_SECOND_ROUND = Color.ORANGE;
+    private static final Color COLOR_REJECTED = Color.RED;
+    private static final Color COLOR_WAITLIST = Color.BROWN;
+    private static final Color COLOR_OFFERED = Color.CYAN;
+    private static final Color COLOR_ACCEPTED = Color.GREEN;
+
+    private static final HashMap<String, String> statusMap = new HashMap<String, String>() {{
+            put(INDEX_STATUS_NEW, STATUS_NEW);
+            put(INDEX_STATUS_INTERVIEW_FIRST_ROUND, STATUS_INTERVIEW_FIRST_ROUND);
+            put(INDEX_STATUS_INTERVIEW_SECOND_ROUND, STATUS_INTERVIEW_SECOND_ROUND);
+            put(INDEX_STATUS_REJECTED, STATUS_REJECTED);
+            put(INDEX_STATUS_WAITLIST, STATUS_WAITLIST);
+            put(INDEX_STATUS_OFFERED, STATUS_OFFERED);
+            put(INDEX_STATUS_ACCEPTED, STATUS_ACCEPTED); }};
+
+    private static final HashMap<String, Color> colorMap = new HashMap<String, Color>() {{
+            put(STATUS_NEW, COLOR_NEW);
+            put(STATUS_INTERVIEW_FIRST_ROUND, COLOR_INTERVIEW_FIRST_ROUND);
+            put(STATUS_INTERVIEW_SECOND_ROUND, COLOR_INTERVIEW_SECOND_ROUND);
+            put(STATUS_REJECTED, COLOR_REJECTED);
+            put(STATUS_WAITLIST, COLOR_WAITLIST);
+            put(STATUS_OFFERED, COLOR_OFFERED);
+            put(STATUS_ACCEPTED, COLOR_ACCEPTED); }};
+
+    public final String value;
+    public final Color color;
+
+    /**
+     * Constructs a {@code Status}.
+     *
+     * @param statusIndex A valid status index.
+     */
+    public Status(String statusIndex) {
+        requireNonNull(statusIndex);
+        String trimmedStatusIndex = statusIndex.trim();
+        checkArgument(isValidStatus(trimmedStatusIndex), MESSAGE_STATUS_CONSTRAINTS);
+        this.value = getStatus(trimmedStatusIndex);
+        this.color = getColor(value);
+    }
+
+    /**
+     * Returns true if a given string is a valid person major.
+     */
+    public static boolean isValidStatus(String test) {
+        return statusMap.containsKey(test);
+    }
+
+    private static String getStatus(String trimmedStatusIndex) {
+        return statusMap.get(trimmedStatusIndex);
+    }
+
+    private static Color getColor(String status) {
+        return colorMap.get(status);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Major // instanceof handles nulls
+                && this.value.equals(((Status) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/Status.java
+++ b/src/main/java/seedu/address/model/person/Status.java
@@ -44,26 +44,30 @@ public class Status {
     public static final Color COLOR_ACCEPTED = Color.GREEN;
     public static final Color COLOR_WITHDRAWN = Color.PURPLE;
 
-    private static final HashMap<Integer, String> STATUS_MAP = new HashMap<Integer, String>() {{
-            put(INDEX_STATUS_NEW, STATUS_NEW);
-            put(INDEX_STATUS_INTERVIEW_FIRST_ROUND, STATUS_INTERVIEW_FIRST_ROUND);
-            put(INDEX_STATUS_INTERVIEW_SECOND_ROUND, STATUS_INTERVIEW_SECOND_ROUND);
-            put(INDEX_STATUS_REJECTED, STATUS_REJECTED);
-            put(INDEX_STATUS_WAITLIST, STATUS_WAITLIST);
-            put(INDEX_STATUS_OFFERED, STATUS_OFFERED);
-            put(INDEX_STATUS_ACCEPTED, STATUS_ACCEPTED);
-            put(INDEX_STATUS_WITHDRAWN, STATUS_WITHDRAWN); }};
-
-    private static final HashMap<String, Color> COLOR_MAP = new HashMap<String, Color>() {{
-            put(STATUS_NEW, COLOR_NEW);
-            put(STATUS_INTERVIEW_FIRST_ROUND, COLOR_INTERVIEW_FIRST_ROUND);
-            put(STATUS_INTERVIEW_SECOND_ROUND, COLOR_INTERVIEW_SECOND_ROUND);
-            put(STATUS_REJECTED, COLOR_REJECTED);
-            put(STATUS_WAITLIST, COLOR_WAITLIST);
-            put(STATUS_OFFERED, COLOR_OFFERED);
-            put(STATUS_ACCEPTED, COLOR_ACCEPTED);
-            put(STATUS_WITHDRAWN, COLOR_WITHDRAWN); }};
-
+    private static final HashMap<Integer, String> STATUS_MAP;
+    static {
+        STATUS_MAP = new HashMap<Integer, String>() {{
+                put(INDEX_STATUS_NEW, STATUS_NEW);
+                put(INDEX_STATUS_INTERVIEW_FIRST_ROUND, STATUS_INTERVIEW_FIRST_ROUND);
+                put(INDEX_STATUS_INTERVIEW_SECOND_ROUND, STATUS_INTERVIEW_SECOND_ROUND);
+                put(INDEX_STATUS_REJECTED, STATUS_REJECTED);
+                put(INDEX_STATUS_WAITLIST, STATUS_WAITLIST);
+                put(INDEX_STATUS_OFFERED, STATUS_OFFERED);
+                put(INDEX_STATUS_ACCEPTED, STATUS_ACCEPTED);
+                put(INDEX_STATUS_WITHDRAWN, STATUS_WITHDRAWN); }};
+    }
+    private static final HashMap<String, Color> COLOR_MAP;
+    static {
+        COLOR_MAP = new HashMap<String, Color>() {{
+                put(STATUS_NEW, COLOR_NEW);
+                put(STATUS_INTERVIEW_FIRST_ROUND, COLOR_INTERVIEW_FIRST_ROUND);
+                put(STATUS_INTERVIEW_SECOND_ROUND, COLOR_INTERVIEW_SECOND_ROUND);
+                put(STATUS_REJECTED, COLOR_REJECTED);
+                put(STATUS_WAITLIST, COLOR_WAITLIST);
+                put(STATUS_OFFERED, COLOR_OFFERED);
+                put(STATUS_ACCEPTED, COLOR_ACCEPTED);
+                put(STATUS_WITHDRAWN, COLOR_WITHDRAWN); }};
+    }
     public final String value;
     public final Color color;
 

--- a/src/main/java/seedu/address/model/person/Status.java
+++ b/src/main/java/seedu/address/model/person/Status.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import javafx.scene.paint.Color;
 
@@ -46,27 +47,29 @@ public class Status {
 
     private static final HashMap<Integer, String> STATUS_MAP;
     static {
-        STATUS_MAP = new HashMap<Integer, String>() {{
-                put(INDEX_STATUS_NEW, STATUS_NEW);
-                put(INDEX_STATUS_INTERVIEW_FIRST_ROUND, STATUS_INTERVIEW_FIRST_ROUND);
-                put(INDEX_STATUS_INTERVIEW_SECOND_ROUND, STATUS_INTERVIEW_SECOND_ROUND);
-                put(INDEX_STATUS_REJECTED, STATUS_REJECTED);
-                put(INDEX_STATUS_WAITLIST, STATUS_WAITLIST);
-                put(INDEX_STATUS_OFFERED, STATUS_OFFERED);
-                put(INDEX_STATUS_ACCEPTED, STATUS_ACCEPTED);
-                put(INDEX_STATUS_WITHDRAWN, STATUS_WITHDRAWN); }};
+        Map<Integer, String> initMap = new HashMap<Integer, String>();
+        initMap.put(INDEX_STATUS_NEW, STATUS_NEW);
+        initMap.put(INDEX_STATUS_INTERVIEW_FIRST_ROUND, STATUS_INTERVIEW_FIRST_ROUND);
+        initMap.put(INDEX_STATUS_INTERVIEW_SECOND_ROUND, STATUS_INTERVIEW_SECOND_ROUND);
+        initMap.put(INDEX_STATUS_REJECTED, STATUS_REJECTED);
+        initMap.put(INDEX_STATUS_WAITLIST, STATUS_WAITLIST);
+        initMap.put(INDEX_STATUS_OFFERED, STATUS_OFFERED);
+        initMap.put(INDEX_STATUS_ACCEPTED, STATUS_ACCEPTED);
+        initMap.put(INDEX_STATUS_WITHDRAWN, STATUS_WITHDRAWN);
+        STATUS_MAP = new HashMap<>(initMap);
     }
     private static final HashMap<String, Color> COLOR_MAP;
     static {
-        COLOR_MAP = new HashMap<String, Color>() {{
-                put(STATUS_NEW, COLOR_NEW);
-                put(STATUS_INTERVIEW_FIRST_ROUND, COLOR_INTERVIEW_FIRST_ROUND);
-                put(STATUS_INTERVIEW_SECOND_ROUND, COLOR_INTERVIEW_SECOND_ROUND);
-                put(STATUS_REJECTED, COLOR_REJECTED);
-                put(STATUS_WAITLIST, COLOR_WAITLIST);
-                put(STATUS_OFFERED, COLOR_OFFERED);
-                put(STATUS_ACCEPTED, COLOR_ACCEPTED);
-                put(STATUS_WITHDRAWN, COLOR_WITHDRAWN); }};
+        Map<String, Color> initMap = new HashMap<String, Color>();
+        initMap.put(STATUS_NEW, COLOR_NEW);
+        initMap.put(STATUS_INTERVIEW_FIRST_ROUND, COLOR_INTERVIEW_FIRST_ROUND);
+        initMap.put(STATUS_INTERVIEW_SECOND_ROUND, COLOR_INTERVIEW_SECOND_ROUND);
+        initMap.put(STATUS_REJECTED, COLOR_REJECTED);
+        initMap.put(STATUS_WAITLIST, COLOR_WAITLIST);
+        initMap.put(STATUS_OFFERED, COLOR_OFFERED);
+        initMap.put(STATUS_ACCEPTED, COLOR_ACCEPTED);
+        initMap.put(STATUS_WITHDRAWN, COLOR_WITHDRAWN);
+        COLOR_MAP = new HashMap<String, Color>(initMap);
     }
     public final String value;
     public final Color color;

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -17,6 +17,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Rating;
 import seedu.address.model.person.Resume;
+import seedu.address.model.person.Status;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.tag.Tag;
 
@@ -33,36 +34,42 @@ public class SampleDataUtil {
                 new Major("Computer Science"),
                 new Rating(4.3, 4.8,
                             4.0, 4.1),
-                new Resume(formPathFromFileName("alex.pdf")), new InterviewDate(1540814400L), getTagSet("friends")),
+                new Resume(formPathFromFileName("alex.pdf")), new InterviewDate(1540814400L),
+                new Status(), getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new ExpectedGraduationYear("2019"),
                     new Major("Computer Science"),
                 new Rating(-1, -1,
                         -1, -1),
-                new Resume(null), new InterviewDate(), getTagSet("colleagues", "friends")),
+                new Resume(null), new InterviewDate(), new Status(1),
+                getTagSet("colleagues", "friends")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new ExpectedGraduationYear("2020"),
                     new Major("Computer Science"),
                 new Rating(4.5, 3,
                         4.5, 2.5),
-                new Resume(formPathFromFileName("char.pdf")), new InterviewDate(), getTagSet("neighbours")),
+                new Resume(formPathFromFileName("char.pdf")), new InterviewDate(), new Status(5),
+                getTagSet("neighbours")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new ExpectedGraduationYear("2020"),
                     new Major("Computer Science"),
                 new Rating(-1, -1,
                         -1, -1),
-                new Resume(null), new InterviewDate(), getTagSet("family")),
+                new Resume(null), new InterviewDate(), new Status(3),
+                getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), new ExpectedGraduationYear("2021"),
                     new Major("Computer Science"),
                 new Rating(3, 5, 3.5, 3),
-                new Resume(null), new InterviewDate(), getTagSet("classmates")),
+                new Resume(null), new InterviewDate(), new Status(4),
+                getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), new ExpectedGraduationYear("2019"),
                     new Major("Computer Science"),
                 new Rating(-1, -1,
                         -1, -1),
-                new Resume(null), new InterviewDate(), getTagSet("colleagues"))
+                new Resume(null), new InterviewDate(), new Status(2),
+                getTagSet("colleagues"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
@@ -184,13 +184,13 @@ public class XmlAdaptedPerson {
         if (this.status == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Status.class.getSimpleName()));
         }
-        if(!Status.isValidXmlStatus(status)){
+        if (!Status.isValidXmlStatus(status)) {
             throw new IllegalValueException(Status.MESSAGE_STATUS_CONSTRAINTS);
         }
         final Status status = new Status(this.status);
 
         if (technicalSkillsScore == null || communicationSkillsScore == null
-                || technicalSkillsScore == null || experienceScore == null
+                || problemSolvingSkillsScore == null || experienceScore == null
                 || !Rating.isValidOrDefaultScore(Double.valueOf(technicalSkillsScore))
                 || !Rating.isValidOrDefaultScore(Double.valueOf(communicationSkillsScore))
                 || !Rating.isValidOrDefaultScore(Double.valueOf(problemSolvingSkillsScore))

--- a/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
@@ -21,6 +21,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Rating;
 import seedu.address.model.person.Resume;
+import seedu.address.model.person.Status;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -43,6 +44,8 @@ public class XmlAdaptedPerson {
     private String expectedGraduationYear;
     @XmlElement(required = true)
     private String major;
+    @XmlElement(required = true)
+    private String status;
     //optional fields
     @XmlElement(nillable = true)
     private String resume;
@@ -73,7 +76,7 @@ public class XmlAdaptedPerson {
     public XmlAdaptedPerson(String name, String phone, String email, String address, String expectedGraduationYear,
                             String major, String technicalSkillsScore, String communicationSkillsScore,
                             String problemSolvingSkillsScore, String experienceScore,
-                            String resume, String interviewDate, List<XmlAdaptedTag> tagged) {
+                            String resume, String interviewDate, String status, List<XmlAdaptedTag> tagged) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -86,6 +89,7 @@ public class XmlAdaptedPerson {
         this.experienceScore = experienceScore;
         this.resume = resume;
         this.interviewDate = interviewDate;
+        this.status = status;
         if (tagged != null) {
             this.tagged = new ArrayList<>(tagged);
         }
@@ -109,6 +113,7 @@ public class XmlAdaptedPerson {
         experienceScore = Double.toString(source.getRating().experienceScore);
         resume = source.getResume().value;
         interviewDate = source.getInterviewDate().toString();
+        status = source.getStatus().value;
         tagged = new ArrayList<>();
         for (Tag tag : source.getTags()) {
             tagged.add(new XmlAdaptedTag(tag));
@@ -176,6 +181,14 @@ public class XmlAdaptedPerson {
         }
         final Major major = new Major(this.major);
 
+        if (this.status == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Status.class.getSimpleName()));
+        }
+        if(!Status.isValidXmlStatus(status)){
+            throw new IllegalValueException(Status.MESSAGE_STATUS_CONSTRAINTS);
+        }
+        final Status status = new Status(this.status);
+
         if (technicalSkillsScore == null || communicationSkillsScore == null
                 || technicalSkillsScore == null || experienceScore == null
                 || !Rating.isValidOrDefaultScore(Double.valueOf(technicalSkillsScore))
@@ -203,7 +216,7 @@ public class XmlAdaptedPerson {
 
         final Set<Tag> tags = new HashSet<>(personTags);
         return new Person(name, phone, email, address, expectedGraduationYear,
-                major, rating, resume, interviewDate, tags);
+                major, rating, resume, interviewDate, status, tags);
     }
 
     @Override
@@ -224,6 +237,7 @@ public class XmlAdaptedPerson {
                 && Objects.equals(expectedGraduationYear, otherPerson.expectedGraduationYear)
                 && Objects.equals(major, otherPerson.major)
                 && Objects.equals(interviewDate, otherPerson.interviewDate)
+                && Objects.equals(status, otherPerson.status)
                 && tagged.equals(otherPerson.tagged);
     }
 }

--- a/src/main/java/seedu/address/ui/InfoPanel.java
+++ b/src/main/java/seedu/address/ui/InfoPanel.java
@@ -165,7 +165,8 @@ public class InfoPanel extends UiPart<Region> {
         infoMainAddress.setText(person.getAddress().value);
         infoMainPhone.setText(person.getPhone().value);
         infoMainPosition.setText("-");
-        infoMainStatus.setText("-");
+        infoMainStatus.setText(person.getStatus().value);
+        infoMainStatus.setTextFill(person.getStatus().color);
         infoMainComments.setText("-");
 
         // Process Interview info

--- a/src/test/data/XmlSerializableAddressBookTest/typicalPersonsAddressBook.xml
+++ b/src/test/data/XmlSerializableAddressBookTest/typicalPersonsAddressBook.xml
@@ -9,6 +9,7 @@
         <address>123, Jurong West Ave 6, #08-111</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Computer Science</major>
+        <status>new</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -22,6 +23,7 @@
         <address>311, Clementi Ave 2, #02-25</address>
         <expectedGraduationYear>2021</expectedGraduationYear>
         <major>Computer Engineering</major>
+        <status>interview first round</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -36,6 +38,7 @@
         <address>wall street</address>
         <expectedGraduationYear>2019</expectedGraduationYear>
         <major>Computer Science</major>
+        <status>new</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -48,6 +51,7 @@
         <address>10th street</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Information Security</major>
+        <status>new</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -60,6 +64,7 @@
         <address>michegan ave</address>
         <expectedGraduationYear>2018</expectedGraduationYear>
         <major>Business Analytics</major>
+        <status>offer accepted</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -72,6 +77,7 @@
         <address>little tokyo</address>
         <expectedGraduationYear>2019</expectedGraduationYear>
         <major>Computer Science</major>
+        <status>new</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -84,6 +90,7 @@
         <address>4th street</address>
         <expectedGraduationYear>2022</expectedGraduationYear>
         <major>Information Systems</major>
+        <status>position offered</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>

--- a/src/test/data/XmlSerializableAddressBookTest/typicalPersonsAddressBook.xml
+++ b/src/test/data/XmlSerializableAddressBookTest/typicalPersonsAddressBook.xml
@@ -9,7 +9,7 @@
         <address>123, Jurong West Ave 6, #08-111</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Computer Science</major>
-        <status>new</status>
+        <status>New</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -23,7 +23,7 @@
         <address>311, Clementi Ave 2, #02-25</address>
         <expectedGraduationYear>2021</expectedGraduationYear>
         <major>Computer Engineering</major>
-        <status>interview first round</status>
+        <status>1st round</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -38,7 +38,7 @@
         <address>wall street</address>
         <expectedGraduationYear>2019</expectedGraduationYear>
         <major>Computer Science</major>
-        <status>new</status>
+        <status>New</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -51,7 +51,7 @@
         <address>10th street</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Information Security</major>
-        <status>new</status>
+        <status>New</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -64,7 +64,7 @@
         <address>michegan ave</address>
         <expectedGraduationYear>2018</expectedGraduationYear>
         <major>Business Analytics</major>
-        <status>offer accepted</status>
+        <status>Accepted</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -77,7 +77,7 @@
         <address>little tokyo</address>
         <expectedGraduationYear>2019</expectedGraduationYear>
         <major>Computer Science</major>
-        <status>new</status>
+        <status>New</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -90,7 +90,7 @@
         <address>4th street</address>
         <expectedGraduationYear>2022</expectedGraduationYear>
         <major>Information Systems</major>
-        <status>position offered</status>
+        <status>Offered</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>

--- a/src/test/data/XmlUtilTest/invalidPersonField.xml
+++ b/src/test/data/XmlUtilTest/invalidPersonField.xml
@@ -7,6 +7,7 @@
     <address>4th street</address>
     <expectedGraduationYear>2020</expectedGraduationYear>
     <major>Computer Science</major>
+    <status>offer accepted</status>
     <interviewDate>1540814400</interviewDate>
     <tagged>friends</tagged>
 </person>

--- a/src/test/data/XmlUtilTest/missingPersonField.xml
+++ b/src/test/data/XmlUtilTest/missingPersonField.xml
@@ -6,6 +6,7 @@
     <address>4th street</address>
     <expectedGraduationYear>2020</expectedGraduationYear>
     <major>Computer Science</major>
+    <status>offer accepted</status>
     <tagged>friends</tagged>
     <interviewDate>1540814400</interviewDate>
 </person>

--- a/src/test/data/XmlUtilTest/validAddressBook.xml
+++ b/src/test/data/XmlUtilTest/validAddressBook.xml
@@ -7,6 +7,7 @@
         <address isPrivate="false">4th street</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Computer Science</major>
+        <status>offer accepted</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -19,6 +20,7 @@
         <address isPrivate="false">81th street</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Computer Engineering</major>
+        <status>new</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -31,6 +33,7 @@
         <address isPrivate="false">wall street</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Information Security</major>
+        <status>interview first round</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -43,6 +46,7 @@
         <address isPrivate="false">10th street</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Computer Science</major>
+        <status>interview second round</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -55,6 +59,7 @@
         <address isPrivate="false">michegan ave</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Information Systems</major>
+        <status>rejected</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -67,6 +72,7 @@
         <address isPrivate="false">little tokyo</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Business Analytics</major>
+        <status>on waitlist</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -79,6 +85,7 @@
         <address isPrivate="false">4th street</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Computer Science</major>
+        <status>position offered</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -91,6 +98,7 @@
         <address isPrivate="false">little india</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Computer Engineering</major>
+        <status>new</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -103,6 +111,7 @@
         <address isPrivate="false">chicago ave</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Information Security</major>
+        <status>new</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>

--- a/src/test/data/XmlUtilTest/validAddressBook.xml
+++ b/src/test/data/XmlUtilTest/validAddressBook.xml
@@ -7,7 +7,7 @@
         <address isPrivate="false">4th street</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Computer Science</major>
-        <status>offer accepted</status>
+        <status>Accepted</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -20,7 +20,7 @@
         <address isPrivate="false">81th street</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Computer Engineering</major>
-        <status>new</status>
+        <status>New</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -33,7 +33,7 @@
         <address isPrivate="false">wall street</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Information Security</major>
-        <status>interview first round</status>
+        <status>1st round</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -46,7 +46,7 @@
         <address isPrivate="false">10th street</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Computer Science</major>
-        <status>interview second round</status>
+        <status>2nd round</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -59,7 +59,7 @@
         <address isPrivate="false">michegan ave</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Information Systems</major>
-        <status>rejected</status>
+        <status>Rejected</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -72,7 +72,7 @@
         <address isPrivate="false">little tokyo</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Business Analytics</major>
-        <status>on waitlist</status>
+        <status>Waitlist</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -85,7 +85,7 @@
         <address isPrivate="false">4th street</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Computer Science</major>
-        <status>position offered</status>
+        <status>Offered</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -98,7 +98,7 @@
         <address isPrivate="false">little india</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Computer Engineering</major>
-        <status>new</status>
+        <status>Withdrawn</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>
@@ -111,7 +111,7 @@
         <address isPrivate="false">chicago ave</address>
         <expectedGraduationYear>2020</expectedGraduationYear>
         <major>Information Security</major>
-        <status>new</status>
+        <status>New</status>
         <technicalSkillsScore isPrivate="false">-1</technicalSkillsScore>
         <communicationSkillsScore isPrivate="false">-1</communicationSkillsScore>
         <problemSolvingSkillsScore isPrivate="false">-1</problemSolvingSkillsScore>

--- a/src/test/data/XmlUtilTest/validPerson.xml
+++ b/src/test/data/XmlUtilTest/validPerson.xml
@@ -6,6 +6,7 @@
     <address>4th street</address>
     <expectedGraduationYear>2020</expectedGraduationYear>
     <major>Computer Science</major>
+    <status>offer accepted</status>
     <resume>src/test/data/XmlUtilTest/hans.pdf</resume>
     <interviewDate>1540814400</interviewDate>
     <tagged>friends</tagged>

--- a/src/test/java/seedu/address/commons/util/XmlUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/XmlUtilTest.java
@@ -47,6 +47,7 @@ public class XmlUtilTest {
     private static final String VALID_EXPERIENCE_SCORE = "2.5";
     private static final String VALID_RESUME = TEST_DATA_FOLDER + "hans.pdf";
     private static final String VALID_INTERVIEW_DATE = "1540814400";
+    private static final String VALID_STATUS = "offer accepted";
     private static final List<XmlAdaptedTag> VALID_TAGS =
             Collections.singletonList(new XmlAdaptedTag("friends"));
 
@@ -92,7 +93,7 @@ public class XmlUtilTest {
                 null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_EXPECTED_GRADUATION_YEAR,
                 VALID_MAJOR, VALID_TECHNICAL_SKILLS_SCORE, VALID_COMMUNICATION_SKILLS_SCORE,
                 VALID_PROBLEM_SOLVING_SKILLS_SCORE, VALID_EXPERIENCE_SCORE, VALID_RESUME,
-                VALID_INTERVIEW_DATE, VALID_TAGS);
+                VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         assertEquals(expectedPerson, actualPerson);
     }
 
@@ -104,7 +105,7 @@ public class XmlUtilTest {
                 VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_EXPECTED_GRADUATION_YEAR,
                 VALID_MAJOR, VALID_TECHNICAL_SKILLS_SCORE, VALID_COMMUNICATION_SKILLS_SCORE,
                 VALID_PROBLEM_SOLVING_SKILLS_SCORE, VALID_EXPERIENCE_SCORE, VALID_RESUME,
-                VALID_INTERVIEW_DATE, VALID_TAGS);
+                VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         assertEquals(expectedPerson, actualPerson);
     }
 
@@ -116,7 +117,7 @@ public class XmlUtilTest {
                 VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_EXPECTED_GRADUATION_YEAR,
                 VALID_MAJOR, VALID_TECHNICAL_SKILLS_SCORE, VALID_COMMUNICATION_SKILLS_SCORE,
                 VALID_PROBLEM_SOLVING_SKILLS_SCORE, VALID_EXPERIENCE_SCORE, VALID_RESUME,
-                VALID_INTERVIEW_DATE, VALID_TAGS);
+                VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         assertEquals(expectedPerson, actualPerson);
     }
 

--- a/src/test/java/seedu/address/logic/commands/StatusCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/StatusCommandTest.java
@@ -14,6 +14,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Test;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;

--- a/src/test/java/seedu/address/logic/commands/StatusCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/StatusCommandTest.java
@@ -1,0 +1,159 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.prepareRedoCommand;
+import static seedu.address.logic.commands.CommandTestUtil.prepareUndoCommand;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.logic.commands.InterviewCommandTest.VALID_DATETIME;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.Test;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.UndoRedoStack;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Status;
+import seedu.address.testutil.PersonBuilder;
+
+public class StatusCommandTest {
+    public static final int VALID_STATUS_INDEX = 7;
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validDateUnfilteredList_success() throws Exception {
+        Person firstPerson = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person updatedPerson = new PersonBuilder(firstPerson).withStatus(VALID_STATUS_INDEX).build();
+
+        StatusCommand statusCommand = prepareCommand(INDEX_FIRST_PERSON, VALID_STATUS_INDEX);
+        String expectedMessage = String.format(StatusCommand.MESSAGE_STATUS_SUCCESS,
+                updatedPerson.getName(), updatedPerson.getStatus().value);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.updatePerson(firstPerson, updatedPerson);
+
+        assertCommandSuccess(statusCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        StatusCommand statusCommand = prepareCommand(outOfBoundIndex, VALID_STATUS_INDEX);
+        assertCommandFailure(statusCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+        StatusCommand statusCommand = prepareCommand(outOfBoundIndex, VALID_STATUS_INDEX);
+        assertCommandFailure(statusCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void executeUndoRedo_validIndexUnfilteredList_success() throws Exception {
+        UndoRedoStack undoRedoStack = new UndoRedoStack();
+        UndoCommand undoCommand = prepareUndoCommand(model, undoRedoStack);
+        RedoCommand redoCommand = prepareRedoCommand(model, undoRedoStack);
+        Person personToUpdateStataus = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person scheduledPerson = new PersonBuilder(personToUpdateStataus).withStatus(VALID_STATUS_INDEX).build();
+        StatusCommand statusCommand = prepareCommand(INDEX_FIRST_PERSON, VALID_STATUS_INDEX);
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        // interview -> first person interview date scheduled
+        statusCommand.execute();
+        undoRedoStack.push(statusCommand);
+
+        // undo -> reverts addressbook back to previous state and filtered person list to show all persons
+        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        // redo -> same first person scheduled again
+        expectedModel.updatePerson(personToUpdateStataus, scheduledPerson);
+        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void executeUndoRedo_invalidIndexUnfilteredList_failure() {
+        UndoRedoStack undoRedoStack = new UndoRedoStack();
+        UndoCommand undoCommand = prepareUndoCommand(model, undoRedoStack);
+        RedoCommand redoCommand = prepareRedoCommand(model, undoRedoStack);
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        StatusCommand statusCommand = prepareCommand(outOfBoundIndex, VALID_STATUS_INDEX);
+
+        // execution failed -> interviewCommand not pushed into undoRedoStack
+        assertCommandFailure(statusCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+
+        // no commands in undoRedoStack -> undoCommand and redoCommand fail
+        assertCommandFailure(undoCommand, model, UndoCommand.MESSAGE_FAILURE);
+        assertCommandFailure(redoCommand, model, RedoCommand.MESSAGE_FAILURE);
+    }
+
+    @Test
+    public void executeUndoRedo_validIndexFilteredList_samePersonScheduled() throws Exception {
+        UndoRedoStack undoRedoStack = new UndoRedoStack();
+        UndoCommand undoCommand = prepareUndoCommand(model, undoRedoStack);
+        RedoCommand redoCommand = prepareRedoCommand(model, undoRedoStack);
+        StatusCommand statusCommand = prepareCommand(INDEX_FIRST_PERSON, VALID_STATUS_INDEX);
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        showPersonAtIndex(model, INDEX_SECOND_PERSON);
+        Person personToUpdateStatus = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person updatedPerson = new PersonBuilder(personToUpdateStatus).withStatus(VALID_STATUS_INDEX).build();
+        // status    -> update status for second person in unfiltered person list /
+        //              first person in filtered person list
+        statusCommand.execute();
+        undoRedoStack.push(statusCommand);
+
+        // undo -> reverts addressbook back to previous state and filtered person list to show all persons
+        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        expectedModel.updatePerson(personToUpdateStatus, updatedPerson);
+        assertNotEquals(personToUpdateStatus, model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()));
+
+        // redo -> same second person scheduled again
+        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        final StatusCommand standardCommand = new StatusCommand(INDEX_FIRST_PERSON, new Status(VALID_STATUS_INDEX));
+
+        // same values -> returns true
+        StatusCommand commandWithSameValues = new StatusCommand(INDEX_FIRST_PERSON, new Status(VALID_STATUS_INDEX));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand == null);
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new InterviewCommand(INDEX_FIRST_PERSON, VALID_DATETIME)));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new StatusCommand(INDEX_SECOND_PERSON, new Status(VALID_STATUS_INDEX))));
+
+    }
+
+    /**
+     * Returns an {@code InterviewCommand}.
+     */
+    private StatusCommand prepareCommand(Index index, int statusIndex) {
+        StatusCommand statusCommand = new StatusCommand(index, new Status(statusIndex));
+        statusCommand.setData(model, new CommandHistory(), new UndoRedoStack());
+        return statusCommand;
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -140,7 +140,7 @@ public class AddCommandParserTest {
         Person expectedPerson = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
                 .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
                 .withExpectedGraduationYear(VALID_EXPECTED_GRADUATION_YEAR_AMY)
-                .withMajor(VALID_MAJOR_AMY)
+                .withMajor(VALID_MAJOR_AMY).withStatus(1)
                 .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND).build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
                         + EXPECTED_GRADUATION_YEAR_DESC_AMY + MAJOR_DESC_AMY

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -37,11 +37,13 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RateCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.StatusCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.ExpectedGraduationYearInKeywordsRangePredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Rating;
+import seedu.address.model.person.Status;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -132,6 +134,13 @@ public class AddressBookParserTest {
         DeleteRatingCommand command = (DeleteRatingCommand) parser.parseCommand(
                 DeleteRatingCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteRatingCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_status() throws Exception {
+        StatusCommand command = (StatusCommand) parser.parseCommand(
+                StatusCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " " + "3");
+        assertEquals(new StatusCommand(INDEX_FIRST_PERSON, new Status(3)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/StatusCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/StatusCommandParserTest.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.Test;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.StatusCommand;
+import seedu.address.model.person.Status;
+
+public class StatusCommandParserTest {
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, StatusCommand.MESSAGE_USAGE);
+    private StatusCommandParser parser = new StatusCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // No status index specified
+        assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
+
+        // No index and no status index specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+
+        // Too many arguments specified
+        assertParseFailure(parser, "1 2 3", MESSAGE_INVALID_FORMAT);
+    }
+
+
+    @Test
+    public void parse_validValue_returnsStatusCommand() {
+        StatusCommand expectedInterviewCommand =
+                new StatusCommand(Index.fromOneBased(2), new Status(5));
+
+        assertParseSuccess(parser, "2 " + "5", expectedInterviewCommand);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/StatusCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/StatusCommandParserTest.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.Test;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.StatusCommand;
 import seedu.address.model.person.Status;

--- a/src/test/java/seedu/address/model/person/StatusTest.java
+++ b/src/test/java/seedu/address/model/person/StatusTest.java
@@ -1,0 +1,52 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import javafx.scene.paint.Color;
+import seedu.address.testutil.Assert;
+
+public class StatusTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> new Status(null));
+    }
+
+    @Test
+    public void constructor_invalidStatus_throwsIllegalArgumentException() {
+        String invalidStatus = "0";
+        Assert.assertThrows(IllegalArgumentException.class, () -> new Status(invalidStatus));
+    }
+
+    @Test
+    public void isValidStatus() {
+        // null
+        Assert.assertThrows(NullPointerException.class, () -> Phone.isValidPhone(null));
+
+        //invalid status
+        assertFalse(Status.isValidStatus("0")); //index out of range
+        assertFalse(Status.isValidStatus("8"));
+        assertFalse(Status.isValidStatus("I")); //not a valid index
+        // valid status
+        assertTrue(Status.isValidStatus("1"));
+        assertTrue(Status.isValidStatus("2"));
+        assertTrue(Status.isValidStatus("3"));
+        assertTrue(Status.isValidStatus("4"));
+        assertTrue(Status.isValidStatus("5"));
+        assertTrue(Status.isValidStatus("6"));
+        assertTrue(Status.isValidStatus("7"));
+    }
+
+    @Test
+    public void constructor_validStatus_rightColor() {
+        Status s = new Status("1");
+        assertEquals(Color.GREY, s.color);
+        s = new Status("5");
+        assertEquals(Color.BROWN, s.color);
+        s = new Status("7");
+        assertEquals(Color.GREEN, s.color);
+    }
+}

--- a/src/test/java/seedu/address/model/person/StatusTest.java
+++ b/src/test/java/seedu/address/model/person/StatusTest.java
@@ -16,9 +16,9 @@ public class StatusTest {
     }
 
     @Test
-    public void constructor_invalidStatus_throwsIllegalArgumentException() {
-        String invalidStatus = "0";
-        Assert.assertThrows(IllegalArgumentException.class, () -> new Status(invalidStatus));
+    public void constructor_invalidStatusIndex_throwsIllegalArgumentException() {
+        int invalidStatusIndex = 0;
+        Assert.assertThrows(IllegalArgumentException.class, () -> new Status(invalidStatusIndex));
     }
 
     @Test
@@ -27,26 +27,34 @@ public class StatusTest {
         Assert.assertThrows(NullPointerException.class, () -> Phone.isValidPhone(null));
 
         //invalid status
-        assertFalse(Status.isValidStatus("0")); //index out of range
-        assertFalse(Status.isValidStatus("8"));
-        assertFalse(Status.isValidStatus("I")); //not a valid index
+        assertFalse(Status.isValidStatus(0)); //index out of range
+        assertFalse(Status.isValidStatus(8));
         // valid status
-        assertTrue(Status.isValidStatus("1"));
-        assertTrue(Status.isValidStatus("2"));
-        assertTrue(Status.isValidStatus("3"));
-        assertTrue(Status.isValidStatus("4"));
-        assertTrue(Status.isValidStatus("5"));
-        assertTrue(Status.isValidStatus("6"));
-        assertTrue(Status.isValidStatus("7"));
+        assertTrue(Status.isValidStatus(1));
+        assertTrue(Status.isValidStatus(2));
+        assertTrue(Status.isValidStatus(3));
+        assertTrue(Status.isValidStatus(4));
+        assertTrue(Status.isValidStatus(5));
+        assertTrue(Status.isValidStatus(6));
+        assertTrue(Status.isValidStatus(7));
     }
 
     @Test
     public void constructor_validStatus_rightColor() {
-        Status s = new Status("1");
+        Status s = new Status(1);
         assertEquals(Color.GREY, s.color);
-        s = new Status("5");
+        s = new Status(5);
         assertEquals(Color.BROWN, s.color);
-        s = new Status("7");
+        s = new Status(7);
         assertEquals(Color.GREEN, s.color);
+        s = new Status();
+        assertEquals(Color.GREY, s.color);
+    }
+
+    @Test
+    public void equals() {
+        Status status1 = new Status();
+        Status status2 = new Status("new");
+        assertEquals(status1, status2);
     }
 }

--- a/src/test/java/seedu/address/model/person/StatusTest.java
+++ b/src/test/java/seedu/address/model/person/StatusTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import javafx.scene.paint.Color;
 import seedu.address.testutil.Assert;
 
 public class StatusTest {
@@ -28,33 +27,30 @@ public class StatusTest {
 
         //invalid status
         assertFalse(Status.isValidStatus(0)); //index out of range
-        assertFalse(Status.isValidStatus(8));
+        assertFalse(Status.isValidStatus(Status.STATUS_TYPE_CONUT + 1));
         // valid status
-        assertTrue(Status.isValidStatus(1));
-        assertTrue(Status.isValidStatus(2));
-        assertTrue(Status.isValidStatus(3));
-        assertTrue(Status.isValidStatus(4));
-        assertTrue(Status.isValidStatus(5));
-        assertTrue(Status.isValidStatus(6));
-        assertTrue(Status.isValidStatus(7));
+        assertTrue(Status.isValidStatus(Status.INDEX_STATUS_REJECTED));
+        assertTrue(Status.isValidStatus(Status.INDEX_STATUS_INTERVIEW_SECOND_ROUND));
+        assertTrue(Status.isValidStatus(Status.INDEX_STATUS_OFFERED));
+        assertTrue(Status.isValidStatus(Status.INDEX_STATUS_WITHDRAWN));
     }
 
     @Test
     public void constructor_validStatus_rightColor() {
-        Status s = new Status(1);
-        assertEquals(Color.GREY, s.color);
-        s = new Status(5);
-        assertEquals(Color.BROWN, s.color);
-        s = new Status(7);
-        assertEquals(Color.GREEN, s.color);
+        Status s = new Status(Status.INDEX_STATUS_INTERVIEW_FIRST_ROUND);
+        assertEquals(Status.COLOR_INTERVIEW_FIRST_ROUND, s.color);
+        s = new Status(Status.INDEX_STATUS_WAITLIST);
+        assertEquals(Status.COLOR_WAITLIST, s.color);
+        s = new Status(Status.INDEX_STATUS_ACCEPTED);
+        assertEquals(Status.COLOR_ACCEPTED, s.color);
         s = new Status();
-        assertEquals(Color.GREY, s.color);
+        assertEquals(Status.COLOR_NEW, s.color);
     }
 
     @Test
     public void equals() {
         Status status1 = new Status();
-        Status status2 = new Status("new");
+        Status status2 = new Status(Status.STATUS_NEW);
         assertEquals(status1, status2);
     }
 }

--- a/src/test/java/seedu/address/storage/XmlAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/XmlAdaptedPersonTest.java
@@ -134,7 +134,7 @@ public class XmlAdaptedPersonTest {
                 VALID_ADDRESS, VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                 VALID_TECHNICAL_SKILLS_SCORE,
                 VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
+                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -146,7 +146,7 @@ public class XmlAdaptedPersonTest {
                         VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                         VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
+                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_ADDRESS_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -157,7 +157,7 @@ public class XmlAdaptedPersonTest {
                 null,  VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                 VALID_TECHNICAL_SKILLS_SCORE,
                 VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
+                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -169,7 +169,7 @@ public class XmlAdaptedPersonTest {
                         INVALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                         VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
+                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = ExpectedGraduationYear.MESSAGE_EXPECTED_GRADUATION_YEAR_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -179,7 +179,7 @@ public class XmlAdaptedPersonTest {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                 VALID_ADDRESS,  null, VALID_MAJOR, VALID_TECHNICAL_SKILLS_SCORE,
                 VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
+                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 ExpectedGraduationYear.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -192,7 +192,7 @@ public class XmlAdaptedPersonTest {
                         VALID_EXPECTED_GRADUATION_YEAR, INVALID_MAJOR,
                         VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
+                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = Major.MESSAGE_MAJOR_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -202,7 +202,7 @@ public class XmlAdaptedPersonTest {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                 VALID_ADDRESS,  VALID_EXPECTED_GRADUATION_YEAR, null, VALID_TECHNICAL_SKILLS_SCORE,
                 VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
+                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 Major.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -213,7 +213,7 @@ public class XmlAdaptedPersonTest {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                 VALID_ADDRESS, VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR, INVALID_TECHNICAL_SKILLS_SCORE,
                 INVALID_COMMUNICATION_SKILLS_SCORE, INVALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                INVALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
+                INVALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = Rating.MESSAGE_RATING_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -224,7 +224,7 @@ public class XmlAdaptedPersonTest {
                 new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR, VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, INVALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
+                        VALID_EXPERIENCE_SCORE, INVALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = Resume.MESSAGE_RESUME_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }

--- a/src/test/java/seedu/address/storage/XmlAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/XmlAdaptedPersonTest.java
@@ -23,6 +23,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Rating;
 import seedu.address.model.person.Resume;
+import seedu.address.model.person.Status;
 import seedu.address.testutil.Assert;
 
 public class XmlAdaptedPersonTest {
@@ -38,6 +39,7 @@ public class XmlAdaptedPersonTest {
     private static final String INVALID_EXPERIENCE_SCORE = "5.5";
     private static final String INVALID_RESUME = "fileDoesNot.exist";
     private static final String INVALID_INTERVIEW_DATE = "Tomorrow";
+    private static final String INVALID_STATUS = "dead";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = BENSON.getName().toString();
@@ -57,6 +59,7 @@ public class XmlAdaptedPersonTest {
             BENSON.getRating().getExperienceScore());
     private static final String VALID_RESUME = BENSON.getResume().toString();
     private static final String VALID_INTERVIEW_DATE = "1540814400";
+    private static final String VALID_STATUS = BENSON.getStatus().toString();
     private static final List<XmlAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(XmlAdaptedTag::new)
             .collect(Collectors.toList());
@@ -74,7 +77,7 @@ public class XmlAdaptedPersonTest {
                         VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                         VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_NAME_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -85,7 +88,7 @@ public class XmlAdaptedPersonTest {
                 VALID_ADDRESS, VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                 VALID_TECHNICAL_SKILLS_SCORE,
                 VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -97,7 +100,7 @@ public class XmlAdaptedPersonTest {
                         VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                         VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_PHONE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -108,7 +111,7 @@ public class XmlAdaptedPersonTest {
                 VALID_ADDRESS, VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                 VALID_TECHNICAL_SKILLS_SCORE,
                 VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -120,7 +123,7 @@ public class XmlAdaptedPersonTest {
                         VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                         VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_EMAIL_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -131,7 +134,7 @@ public class XmlAdaptedPersonTest {
                 VALID_ADDRESS, VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                 VALID_TECHNICAL_SKILLS_SCORE,
                 VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -143,7 +146,7 @@ public class XmlAdaptedPersonTest {
                         VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                         VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_ADDRESS_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -154,7 +157,7 @@ public class XmlAdaptedPersonTest {
                 null,  VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                 VALID_TECHNICAL_SKILLS_SCORE,
                 VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -166,7 +169,7 @@ public class XmlAdaptedPersonTest {
                         INVALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR,
                         VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
         String expectedMessage = ExpectedGraduationYear.MESSAGE_EXPECTED_GRADUATION_YEAR_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -176,7 +179,7 @@ public class XmlAdaptedPersonTest {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                 VALID_ADDRESS,  null, VALID_MAJOR, VALID_TECHNICAL_SKILLS_SCORE,
                 VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 ExpectedGraduationYear.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -189,17 +192,17 @@ public class XmlAdaptedPersonTest {
                         VALID_EXPECTED_GRADUATION_YEAR, INVALID_MAJOR,
                         VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
         String expectedMessage = Major.MESSAGE_MAJOR_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
-    public void toModelType_nullExpectedMajor_throwsIllegalValueException() {
+    public void toModelType_nullMajor_throwsIllegalValueException() {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                 VALID_ADDRESS,  VALID_EXPECTED_GRADUATION_YEAR, null, VALID_TECHNICAL_SKILLS_SCORE,
                 VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 Major.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -210,7 +213,7 @@ public class XmlAdaptedPersonTest {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                 VALID_ADDRESS, VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR, INVALID_TECHNICAL_SKILLS_SCORE,
                 INVALID_COMMUNICATION_SKILLS_SCORE, INVALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                INVALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                INVALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
         String expectedMessage = Rating.MESSAGE_RATING_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -221,7 +224,7 @@ public class XmlAdaptedPersonTest {
                 new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR, VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, INVALID_RESUME, VALID_INTERVIEW_DATE, VALID_TAGS);
+                        VALID_EXPERIENCE_SCORE, INVALID_RESUME, VALID_INTERVIEW_DATE,VALID_STATUS, VALID_TAGS);
         String expectedMessage = Resume.MESSAGE_RESUME_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -232,8 +235,30 @@ public class XmlAdaptedPersonTest {
                 new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR, VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, VALID_RESUME, INVALID_INTERVIEW_DATE, VALID_TAGS);
+                        VALID_EXPERIENCE_SCORE, VALID_RESUME, INVALID_INTERVIEW_DATE, VALID_STATUS, VALID_TAGS);
         String expectedMessage = InterviewDate.MESSAGE_INTERVIEW_DATE_XML_ERROR;
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullStatus_throwsIllegalValueException() {
+        XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS,  VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR, VALID_TECHNICAL_SKILLS_SCORE,
+                VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
+                VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, null, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                Status.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidStatus_throwsIllegalValueException() {
+        XmlAdaptedPerson person =
+                new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR, VALID_TECHNICAL_SKILLS_SCORE,
+                        VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
+                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, INVALID_STATUS, VALID_TAGS);
+        String expectedMessage = Status.MESSAGE_STATUS_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -245,7 +270,7 @@ public class XmlAdaptedPersonTest {
                 new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         VALID_EXPECTED_GRADUATION_YEAR, VALID_MAJOR, VALID_TECHNICAL_SKILLS_SCORE,
                         VALID_COMMUNICATION_SKILLS_SCORE, VALID_PROBLEM_SOLVING_SKILLS_SCORE,
-                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, invalidTags);
+                        VALID_EXPERIENCE_SCORE, VALID_RESUME, VALID_INTERVIEW_DATE, VALID_STATUS, invalidTags);
         Assert.assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -16,6 +16,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Rating;
 import seedu.address.model.person.Resume;
+import seedu.address.model.person.Status;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -47,6 +48,7 @@ public class PersonBuilder {
     private Rating rating;
     private Resume resume;
     private InterviewDate interviewDate;
+    private Status status;
 
     private Set<Tag> tags;
 
@@ -63,6 +65,7 @@ public class PersonBuilder {
                 Double.valueOf(DEFAULT_EXPERIENCE_SCORE));
         resume = new Resume(formPathFromFileName(DEFAULT_RESUME));
         interviewDate = new InterviewDate();
+        status = new Status();
         tags = SampleDataUtil.getTagSet(DEFAULT_TAGS);
     }
 
@@ -79,6 +82,7 @@ public class PersonBuilder {
         rating = personToCopy.getRating();
         resume = personToCopy.getResume();
         interviewDate = personToCopy.getInterviewDate();
+        status = personToCopy.getStatus();
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -166,11 +170,19 @@ public class PersonBuilder {
     }
 
     /**
+     * Sets the {@code Status} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withStatus(int statusIndex) {
+        this.status = new Status(statusIndex);
+        return this;
+    }
+
+    /**
      * Builds and returns a {@code Person}.
      */
     public Person build() {
         return new Person(name, phone, email, address, expectedGraduationYear,
-                major, rating, resume, interviewDate, tags);
+                major, rating, resume, interviewDate, status, tags);
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -52,7 +52,7 @@ public class TypicalPersons {
             .withMajor("Computer Engineering")
             .withRating("4", "4.5",
                     "3", "3.5")
-            .withTags("owesMoney", "friends").build();
+            .withStatus(2).withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street")
             .withExpectedGraduationYear("2019")
@@ -71,20 +71,20 @@ public class TypicalPersons {
             .withExpectedGraduationYear("2018")
             .withMajor("Business Analytics")
             .withRating("-1", "-1",
-                    "-1", "-1").build();
+                    "-1", "-1").withStatus(7).build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo")
             .withExpectedGraduationYear("2019")
             .withMajor("Computer Science")
             .withRating("-1", "-1",
-                    "-1", "-1").build();
+                    "-1", "-1").withStatus(1).build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
             .withEmail("anna@example.com").withAddress("4th street")
             .withExpectedGraduationYear("2022")
             .withMajor("Information Systems")
             .withRating("-1", "-1",
                     "-1", "-1")
-            .withResume(formPathFromFileName("george.pdf")).build();
+            .withResume(formPathFromFileName("george.pdf")).withStatus(6).build();
     public static final Person ALICE_WITHOUT_TAG = new PersonBuilder(ALICE).withTags().build();
     public static final Person BENSON_WITH_FRIENDS_TAG_REMOVED = new PersonBuilder(BENSON)
             .withTags("owesMoney").build();


### PR DESCRIPTION
This PR fixes #47 
In this PR, a new `Status` field is added, which indicates the application status of an applicant. 
The status of any applicant is initialised to be `new` when added. 
The status can be updated with the `status INDEX STATUS_INDEX` command. 

Tests are also updated.

The status is also displayed on GUI will different colours corresponding to the different status. 
However, the selected person does not refresh itself, so it has the same problem as `Rating`.