### PR TITLE
Improve filter command II

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,8 +12,11 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_EXPECTED_GRADUATION_YEAR = new Prefix("y/");
     public static final Prefix PREFIX_MAJOR = new Prefix("m/");
-    public static final Prefix PREFIX_RESUME = new Prefix("r/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    //used only in add/edit command
+    public static final Prefix PREFIX_RESUME = new Prefix("r/");
+    //used only in filter command
+    public static final Prefix PREFIX_RATING = new Prefix("r/");
 
     public static final Prefix PREFIX_TECHNICAL_SKILLS_SCORE = new Prefix("t/");
     public static final Prefix PREFIX_COMMUNICATION_SKILLS_SCORE = new Prefix("c/");

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPECTED_GRADUATION_YEAR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_RESUME;
 
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -24,7 +23,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      */
     public FilterCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_EXPECTED_GRADUATION_YEAR, PREFIX_RATING); //PREFIX_TAG temporarily removed
+                ArgumentTokenizer.tokenize(args, PREFIX_EXPECTED_GRADUATION_YEAR, PREFIX_RATING);
 
         if (!isValidFilterCommandInput(argMultimap, PREFIX_EXPECTED_GRADUATION_YEAR, PREFIX_RATING)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -45,6 +44,12 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         }
     }
 
+    /**
+     * checks whether the user input is of the correct format in the sense that it contains at least 1 prefix
+     * @param argumentMultimap Parsed user input
+     * @param prefixes Supported prefixes
+     * @return whether the input is valid
+     */
     private boolean isValidFilterCommandInput(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         boolean hasAnyPrefixes = false;
         for (Prefix p: prefixes) {
@@ -55,12 +60,16 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         }
         return hasAnyPrefixes;
     }
+
+    /**
+     * combines all the predicate into one predicate AND-connected
+     * @param predicates all the predicates to be combined
+     * @return a single predicate
+     */
     private Predicate<Person> combinePredicate(Predicate<Person>... predicates) {
         Predicate<Person> combinedPredicate = null;
-        for(Predicate<Person> p: predicates) {
-            if (p == null) {
-                continue;
-            } else {
+        for (Predicate<Person> p: predicates) {
+            if (p != null) {
                 if (combinedPredicate == null) {
                     combinedPredicate = p;
                 } else {

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPECTED_GRADUATION_YEAR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RESUME;
 
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -22,9 +24,9 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      */
     public FilterCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_EXPECTED_GRADUATION_YEAR); //PREFIX_TAG temporarily removed
+                ArgumentTokenizer.tokenize(args, PREFIX_EXPECTED_GRADUATION_YEAR, PREFIX_RATING); //PREFIX_TAG temporarily removed
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_EXPECTED_GRADUATION_YEAR)
+        if (!isValidFilterCommandInput(argMultimap, PREFIX_EXPECTED_GRADUATION_YEAR, PREFIX_RATING)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
@@ -32,7 +34,10 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         try {
             Predicate<Person> expectedGraduationYearPredicate = FilterUtil.parseExpectedGraduationYear(argMultimap
                     .getValue(PREFIX_EXPECTED_GRADUATION_YEAR));
-            return new FilterCommand(expectedGraduationYearPredicate);
+            Predicate<Person> ratingPredicate = FilterUtil.parseRating(argMultimap.getValue(PREFIX_RATING));
+            // combine all predicates together using and
+            Predicate<Person> combinedPredicate = combinePredicate(expectedGraduationYearPredicate, ratingPredicate);
+            return new FilterCommand(combinedPredicate);
         } catch (ParseException pe) {
             throw pe;
         } catch (IllegalValueException ive) {
@@ -40,7 +45,31 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         }
     }
 
-
+    private boolean isValidFilterCommandInput(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        boolean hasAnyPrefixes = false;
+        for (Prefix p: prefixes) {
+            if (arePrefixesPresent(argumentMultimap, p)) {
+                hasAnyPrefixes = true;
+                break;
+            }
+        }
+        return hasAnyPrefixes;
+    }
+    private Predicate<Person> combinePredicate(Predicate<Person>... predicates) {
+        Predicate<Person> combinedPredicate = null;
+        for(Predicate<Person> p: predicates) {
+            if (p == null) {
+                continue;
+            } else {
+                if (combinedPredicate == null) {
+                    combinedPredicate = p;
+                } else {
+                    combinedPredicate = combinedPredicate.and(p);
+                }
+            }
+        }
+        return combinedPredicate;
+    }
 
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given

--- a/src/main/java/seedu/address/logic/parser/FilterUtil.java
+++ b/src/main/java/seedu/address/logic/parser/FilterUtil.java
@@ -167,6 +167,12 @@ public class FilterUtil {
         return combineAllPredicates(allPredicates);
     }
 
+    /**
+     * Form a single predicate from a single predicate string
+     * @param s a single predicate string
+     * @return a single predicate
+     * @throws IllegalValueException
+     */
     private static Predicate<Person> formRatingPredicateFromPredicateString(String s)
             throws IllegalValueException {
         FilterRange<Rating> filterRange;

--- a/src/main/java/seedu/address/model/person/ExpectedGraduationYearInKeywordsRangePredicate.java
+++ b/src/main/java/seedu/address/model/person/ExpectedGraduationYearInKeywordsRangePredicate.java
@@ -5,7 +5,7 @@ import java.util.function.Predicate;
 import seedu.address.logic.parser.FilterRange;
 
 /**
- * A Predicate testing whether  a person has his/her expected graduation year in the keywords range
+ * A Predicate testing whether a person has his/her expected graduation year in the keywords range
  */
 public class ExpectedGraduationYearInKeywordsRangePredicate implements Predicate<Person> {
     private final String low;

--- a/src/main/java/seedu/address/model/person/RatingInKeywordsRangePredicate.java
+++ b/src/main/java/seedu/address/model/person/RatingInKeywordsRangePredicate.java
@@ -4,6 +4,9 @@ import java.util.function.Predicate;
 
 import seedu.address.logic.parser.FilterRange;
 
+/**
+ * A Predicate testing whether a person has his/her rating in the keywords range
+ */
 public class RatingInKeywordsRangePredicate implements Predicate<Person> {
     private final double low;
     private final double high;

--- a/src/main/java/seedu/address/model/person/RatingInKeywordsRangePredicate.java
+++ b/src/main/java/seedu/address/model/person/RatingInKeywordsRangePredicate.java
@@ -1,0 +1,38 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+import seedu.address.logic.parser.FilterRange;
+
+public class RatingInKeywordsRangePredicate implements Predicate<Person> {
+    private final double low;
+    private final double high;
+    public RatingInKeywordsRangePredicate(Rating low, Rating high) {
+        this.low = low.getOverallScore();
+        this.high = high.getOverallScore();
+    }
+
+    public RatingInKeywordsRangePredicate(FilterRange<Rating> filterRange) {
+        if (filterRange.isRange()) {
+            this.low = filterRange.getLowValue().getOverallScore();
+            this.high = filterRange.getHighValue().getOverallScore();
+        } else {
+            this.low = filterRange.getExactValue().getOverallScore();
+            this.high = filterRange.getExactValue().getOverallScore();
+        }
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getRating().getOverallScore() <= high
+                && person.getRating().getOverallScore() >= low;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RatingInKeywordsRangePredicate // instanceof handles nulls
+                && this.low == ((RatingInKeywordsRangePredicate) other).low
+                && this.high == ((RatingInKeywordsRangePredicate) other).high); // state check
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.FIONA;
@@ -63,24 +64,52 @@ public class FilterCommandTest {
     @Test
     public void execute_noPersonsGraduationYear_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        FilterCommand command = prepareCommand("2017");
+        FilterCommand command = prepareCommandForExpectedGraduationYearPredicate("2017");
         assertCommandSuccess(command, expectedMessage, Collections.emptyList());
     }
 
     @Test
     public void execute_moderateGraduationYear_somePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 4);
-        FilterCommand command = prepareCommand("2019-2020");
+        FilterCommand command = prepareCommandForExpectedGraduationYearPredicate("2019-2020");
         assertCommandSuccess(command, expectedMessage, Arrays.asList(ALICE, CARL, DANIEL,  FIONA));
     }
 
+    @Test
+    public void execute_noRating_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        FilterCommand command = prepareCommandForRatingPredicate("1.0");
+        assertCommandSuccess(command, expectedMessage, Collections.emptyList());
+    }
+
+    @Test
+    public void execute_moderateRating_somePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        FilterCommand command = prepareCommandForRatingPredicate("2.0-5.0");
+        assertCommandSuccess(command, expectedMessage, Arrays.asList(ALICE, BENSON));
+    }
+
     /**
-     * Parses {@code userInput} into a {@code FindCommand}.
+     * Parses {@code userInput} used for expected graduation year into a {@code FindCommand}.
      */
-    private FilterCommand prepareCommand(String userInput) {
+    private FilterCommand prepareCommandForExpectedGraduationYearPredicate(String userInput) {
         try {
             FilterCommand command =
                     new FilterCommand(FilterUtil.parseExpectedGraduationYear(userInput));
+            command.setData(model, new CommandHistory(), new UndoRedoStack());
+            return command;
+        } catch (IllegalValueException ive) {
+            throw new AssertionError("This should not be reachable.");
+        }
+    }
+
+    /**
+     * Parses {@code userInput} for rating into a {@code FindCommand}.
+     */
+    private FilterCommand prepareCommandForRatingPredicate(String userInput) {
+        try {
+            FilterCommand command =
+                    new FilterCommand(FilterUtil.parseRating(userInput));
             command.setData(model, new CommandHistory(), new UndoRedoStack());
             return command;
         } catch (IllegalValueException ive) {

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -9,6 +9,8 @@ import org.junit.Test;
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.model.person.ExpectedGraduationYear;
 import seedu.address.model.person.ExpectedGraduationYearInKeywordsRangePredicate;
+import seedu.address.model.person.Rating;
+import seedu.address.model.person.RatingInKeywordsRangePredicate;
 
 public class FilterCommandParserTest {
     private FilterCommandParser parser = new FilterCommandParser();
@@ -32,12 +34,25 @@ public class FilterCommandParserTest {
                         new FilterRange<ExpectedGraduationYear>(
                                 new ExpectedGraduationYear("2019"), new ExpectedGraduationYear("2021"))));
         assertParseSuccess(parser, " y/2019-2021", expectedFilterCommand);
+
+        expectedFilterCommand =
+                new FilterCommand(new RatingInKeywordsRangePredicate(
+                        new FilterRange<>(
+                                new Rating(2.22, 2.22, 2.22, 2.22), new Rating(2.22, 2.22, 2.22, 2.22))));
+        assertParseSuccess(parser, " r/2.22", expectedFilterCommand);
+
+        expectedFilterCommand =
+                new FilterCommand(new RatingInKeywordsRangePredicate(
+                        new FilterRange<>(
+                                new Rating(1.22, 1.22, 1.22, 1.22), new Rating(3.22, 3.22, 3.22, 3.22))));
+        assertParseSuccess(parser, " r/1.22-3.22", expectedFilterCommand);
     }
 
     @Test
     public void parse_invalidArg_throwsParseException() {
         //Missing input, invalid command format
         assertParseFailure(parser, "y/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "r/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "   y/2025--2025",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "   y/-",
@@ -46,13 +61,21 @@ public class FilterCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "   y/,,",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
-        //Correct command format but invalid expected graduation year
+        assertParseFailure(parser, " r/2.22 - ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        //Correct command format but invalid field value
         assertParseFailure(parser, "   y/2o2o",
                 ExpectedGraduationYear.MESSAGE_EXPECTED_GRADUATION_YEAR_CONSTRAINTS);
         assertParseFailure(parser, "   y/2025,,2025",
                 ExpectedGraduationYear.MESSAGE_EXPECTED_GRADUATION_YEAR_CONSTRAINTS);
+        assertParseFailure(parser, "   y/2020 r/f",
+                Rating.MESSAGE_RATING_CONSTRAINTS);
+        assertParseFailure(parser, " r/-3.45 ",
+                Rating.MESSAGE_RATING_CONSTRAINTS);
         //Both mistakes occured, detect invalid command format first
         assertParseFailure(parser, "   y/2025--2025,2o2o",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "   y/2025 r/1--100",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
 
     }

--- a/src/test/java/seedu/address/logic/parser/FilterUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterUtilTest.java
@@ -9,6 +9,8 @@ import org.junit.rules.ExpectedException;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.ExpectedGraduationYear;
 import seedu.address.model.person.ExpectedGraduationYearInKeywordsRangePredicate;
+import seedu.address.model.person.Rating;
+import seedu.address.model.person.RatingInKeywordsRangePredicate;
 
 public class FilterUtilTest {
     @Rule
@@ -41,5 +43,34 @@ public class FilterUtilTest {
         assertEquals(new ExpectedGraduationYearInKeywordsRangePredicate(
                         new FilterRange<>(new ExpectedGraduationYear("2020"), new ExpectedGraduationYear("2024"))),
                 FilterUtil.parseExpectedGraduationYear("    2020    - 2024 "));
+    }
+
+    @Test
+    public void parseRating_invalidCommandFormat_throwsIllegalValueException() throws Exception {
+        thrown.expect(IllegalValueException.class);
+        FilterUtil.parseRating("  ");
+    }
+
+    @Test
+    public void parseRating_outOfRangeInput_throwsIllegalValueException() throws Exception {
+        thrown.expect(IllegalValueException.class);
+        FilterUtil.parseRating("6");
+    }
+
+    @Test
+    public void parseRating_validInput_success() throws Exception {
+        //Single value
+        //No whitespaces
+        assertEquals(new RatingInKeywordsRangePredicate(
+                        new FilterRange<>(new Rating(2.2, 2.2, 2.2, 2.2))),
+                FilterUtil.parseRating("2.2"));
+        //With whitespaces
+        assertEquals(new RatingInKeywordsRangePredicate(
+                        new FilterRange<>(new Rating(2.9, 2.9, 2.9, 2.9))),
+                FilterUtil.parseRating("    2.9     "));
+        //Multiple values with whitespaces
+        assertEquals(new RatingInKeywordsRangePredicate(
+                        new FilterRange<>(new Rating(1.0, 1.0, 1.0, 1.0), new Rating(4.0, 4.0, 4.0, 4.0))),
+                FilterUtil.parseRating("    1.001  -   4.001   "));
     }
 }

--- a/src/test/java/seedu/address/model/person/RatingInKeywordsRangePredicateTest.java
+++ b/src/test/java/seedu/address/model/person/RatingInKeywordsRangePredicateTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+
 import seedu.address.logic.parser.FilterRange;
 import seedu.address.testutil.Assert;
 import seedu.address.testutil.PersonBuilder;
@@ -54,8 +55,8 @@ public class RatingInKeywordsRangePredicateTest {
 
         // Ranged keyword
         predicate = new RatingInKeywordsRangePredicate(new FilterRange<Rating>(
-                new Rating(2.0,2.0,2.0,2.0), new Rating(2.1,2.1,2.1,2.1)));
-        assertTrue(predicate.test(new PersonBuilder().withRating("2.3", "1.9","2.0","1.99").build()));
+                new Rating(2.0, 2.0, 2.0, 2.0), new Rating(2.1, 2.1, 2.1, 2.1)));
+        assertTrue(predicate.test(new PersonBuilder().withRating("2.3", "1.9", "2.0", "1.99").build()));
 
     }
 
@@ -69,7 +70,7 @@ public class RatingInKeywordsRangePredicateTest {
 
         // Not-in-range keyword for ranged predicate
         predicate = new RatingInKeywordsRangePredicate(new FilterRange<Rating>(
-                new Rating(2.0,2.0,2.0,2.0), new Rating(2.1,2.1,2.1,2.1)));
+                new Rating(2.0, 2.0, 2.0, 2.0), new Rating(2.1, 2.1, 2.1, 2.1)));
         assertFalse(predicate.test(new PersonBuilder().withRating("2.0", "2.2", "2.2", "2.2").build()));
     }
 

--- a/src/test/java/seedu/address/model/person/RatingInKeywordsRangePredicateTest.java
+++ b/src/test/java/seedu/address/model/person/RatingInKeywordsRangePredicateTest.java
@@ -72,5 +72,5 @@ public class RatingInKeywordsRangePredicateTest {
                 new Rating(2.0,2.0,2.0,2.0), new Rating(2.1,2.1,2.1,2.1)));
         assertFalse(predicate.test(new PersonBuilder().withRating("2.0", "2.2", "2.2", "2.2").build()));
     }
-    
+
 }

--- a/src/test/java/seedu/address/model/person/RatingInKeywordsRangePredicateTest.java
+++ b/src/test/java/seedu/address/model/person/RatingInKeywordsRangePredicateTest.java
@@ -1,0 +1,76 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import seedu.address.logic.parser.FilterRange;
+import seedu.address.testutil.Assert;
+import seedu.address.testutil.PersonBuilder;
+
+public class RatingInKeywordsRangePredicateTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> new RatingInKeywordsRangePredicate(null));
+    }
+
+    @Test
+    public void equals() {
+        FilterRange<Rating> firstPredicateFilterRange = new FilterRange<>(
+                new Rating(3.0, 3.0, 3.0, 3.0), new Rating(4.0, 4.0, 4.0, 4.0));
+        FilterRange<Rating> secondPredicateFilterRange = new FilterRange<>(
+                new Rating(2.97, 2.97, 2.97, 2.97));
+
+        RatingInKeywordsRangePredicate firstPredicate =
+                new RatingInKeywordsRangePredicate(firstPredicateFilterRange);
+        RatingInKeywordsRangePredicate secondPredicate =
+                new RatingInKeywordsRangePredicate(secondPredicateFilterRange);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        RatingInKeywordsRangePredicate firstPredicateCopy =
+                new RatingInKeywordsRangePredicate(firstPredicateFilterRange);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate == null);
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_ratingInKeywordsRange_returnsTrue() {
+        // Single keyword
+        RatingInKeywordsRangePredicate predicate =
+                new RatingInKeywordsRangePredicate(
+                        new FilterRange<Rating>(new Rating(2.97, 2.97, 2.97, 2.97)));
+        assertTrue(predicate.test(new PersonBuilder().withRating("2.95", "2.99", "2.98", "2.96").build()));
+
+        // Ranged keyword
+        predicate = new RatingInKeywordsRangePredicate(new FilterRange<Rating>(
+                new Rating(2.0,2.0,2.0,2.0), new Rating(2.1,2.1,2.1,2.1)));
+        assertTrue(predicate.test(new PersonBuilder().withRating("2.3", "1.9","2.0","1.99").build()));
+
+    }
+
+    @Test
+    public void test_ratingNotInKeywordsRange_returnsFalse() {
+        // Non-matching keyword for single predicate
+        RatingInKeywordsRangePredicate predicate =
+                new RatingInKeywordsRangePredicate(
+                        new FilterRange<Rating>(new Rating(2.97, 2.97, 2.97, 2.97)));
+        assertFalse(predicate.test(new PersonBuilder().withRating("2.95", "3.1", "2.98", "2.96").build()));
+
+        // Not-in-range keyword for ranged predicate
+        predicate = new RatingInKeywordsRangePredicate(new FilterRange<Rating>(
+                new Rating(2.0,2.0,2.0,2.0), new Rating(2.1,2.1,2.1,2.1)));
+        assertFalse(predicate.test(new PersonBuilder().withRating("2.0", "2.2", "2.2", "2.2").build()));
+    }
+    
+}

--- a/src/test/java/systemtests/FilterCommandSystemTest.java
+++ b/src/test/java/systemtests/FilterCommandSystemTest.java
@@ -5,7 +5,9 @@ import static org.junit.Assert.assertFalse;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPECTED_GRADUATION_YEAR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
@@ -24,6 +26,7 @@ import seedu.address.model.Model;
 public class FilterCommandSystemTest extends AddressBookSystemTest {
     @Test
     public void filter() {
+        //Expected Graduation Year filtering
         /* Case: filters multiple persons in address book, command with leading spaces and trailing spaces
          * -> 3 persons found
          */
@@ -69,6 +72,68 @@ public class FilterCommandSystemTest extends AddressBookSystemTest {
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
+        //Rating filtering
+        /* Case: filters multiple persons in address book, command with leading spaces and trailing spaces
+         * -> 2 persons found
+         */
+        showAllPersons();
+        command = "   " + FilterCommand.COMMAND_WORD + " "
+                + PREFIX_RATING + "   3.75" + "   ";
+        expectedModel = getModel();
+        ModelHelper.setFilteredList(expectedModel, BENSON); // their graduation year is before or equal 2019
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: repeat previous filter command where person list is displaying the persons satisfying the filter
+         * -> 2 persons found
+         */
+        command = FilterCommand.COMMAND_WORD + " " + PREFIX_RATING + "3.75";
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: filter person twice -> 5 persons found and 2 persons found*/
+        showAllPersons();
+        command = FilterCommand.COMMAND_WORD + " " + PREFIX_RATING + "2-5";
+        ModelHelper.setFilteredList(expectedModel, ALICE, BENSON);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+        command = FilterCommand.COMMAND_WORD + " " + PREFIX_RATING + "3-5";
+        ModelHelper.setFilteredList(expectedModel, BENSON);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: filter no person in address book, 2017 -> 0 persons found */
+        showAllPersons();
+        command = FilterCommand.COMMAND_WORD + " " + PREFIX_RATING + "1.0";
+        ModelHelper.setFilteredList(expectedModel);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: filter multiple persons in address book, 2 keywords -> 3 persons found */
+        showAllPersons();
+        command = FilterCommand.COMMAND_WORD + " " + PREFIX_RATING + "1.0" + " "
+                + PREFIX_RATING + "3.75";
+        ModelHelper.setFilteredList(expectedModel, BENSON); //only last keyword effective
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        //Mixed filtering - will update more after the larger test sample is generated
+        showAllPersons();
+        command = "   " + FilterCommand.COMMAND_WORD + " " + PREFIX_RATING + " 1-5" + " "
+                + PREFIX_EXPECTED_GRADUATION_YEAR + "2021";
+        expectedModel = getModel();
+        ModelHelper.setFilteredList(expectedModel, BENSON); // their graduation year is before or equal 2019
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        // general cases
+        //setup a filter
+        showAllPersons();
+        command = FilterCommand.COMMAND_WORD + " " + PREFIX_EXPECTED_GRADUATION_YEAR + "2018" + " "
+                + PREFIX_EXPECTED_GRADUATION_YEAR + KEYWORD_MATCHING_2019;
+        ModelHelper.setFilteredList(expectedModel, CARL, FIONA); //only last keyword effective
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
 
         /* Case: undo previous filter command -> rejected */
         command = UndoCommand.COMMAND_WORD;


### PR DESCRIPTION
This PR partially fixes #49 
`filter` command now supports filtering by overall `Rating`. #49 will be addressed again when `cGpa` field is added in the future. `Status` will also be filterable but it will address in a separate PR since #53 has not yet merged at the time of this PR.