### PR TITLE
Add a rating_sort command to sort current list of students based on overall rating

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -195,7 +195,7 @@ Selects the 2nd person in the address book.
 `select 1` +
 Selects the 1st person in the results of the `find` command.
 
-=== Rating a student : `rate`
+=== Rating a student : `rate` [since v1.1]
 
 Rates the student identified by the index number used in the last person listing. +
 Format: `rate INDEX t/TECHNICAL_SKILLS_SCORE c/COMMUNICATION_SKILLS_SCORE p/PROBLEM_SOLVING_SKILLS_SCORE e/EXPERIENCE_SKILLS_SCORE`
@@ -213,7 +213,24 @@ Rates the 1st person to have technical skills score of 4.5, communication skills
 * `rate 2 t/3 c/5 p/3.5 e/2` +
 Rates the 2nd person to have technical skills score of 3, communication skills score of 5, problem solving skills of 3.5, experience score of 2.
 
-=== Deleting the rating given to an applicant : `deleteRating`
+=== Sorting the list of students based on overall rating score : `rating_sort` [since v1.3]
+
+Sorts the current list of students in HR+ based on overall rating score in descending or ascending order. +
+Format: `rating_sort o/SORT ORDER`
+
+****
+* The sort order can only be `asc` (ascending order) or `desc` (descending order).
+* If the list has been filtered, only current students on the list will be sorted instead of all students in HR+.
+****
+
+Examples:
+
+* `rating_sort o/acs` +
+Sorts the current list of students according to their overall rating in ascending order.
+* `rating_sort o/desc` +
+Sorts the current list of students according to their overall rating in descending order.
+
+=== Deleting the rating given to an applicant : `deleteRating` [since v1.2]
 
 Deletes the rating given to the applicant identified by the index number used in the last person listing. +
 Format: `deleteRating INDEX`
@@ -343,7 +360,9 @@ e.g. `filter y/2019`
 e.g.`select 2`
 * *Rate* : `rate INDEX t/TECHNICAL_SKILLS_SCORE c/COMMUNICATION_SKILLS_SCORE p/PROBLEM_SOLVING_SKILLS_SCORE e/EXPERIENCE_SKILLS_SCORE` +
 e.g. `rate 1 t/4.5 c/3 p/4 e/3.5`
-* *deleteRating* : `deleteRating INDEX` +
+* *Rating Sort* : `rating_sort o/SORT ORDER` +
+e.g. `rating_sort o/asc`
+* *Delete Rating* : `deleteRating INDEX` +
 e.g. `deleteRating 1`
 * *History* : `history`
 * *Undo* : `undo`

--- a/src/main/java/seedu/address/logic/commands/RatingSortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RatingSortCommand.java
@@ -1,0 +1,93 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_ORDER;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+
+/**
+ * Sorts and lists all students in HR+ based on overall rating
+ */
+public class RatingSortCommand extends Command {
+
+    public static final String COMMAND_WORD = "rating_sort";
+    public static final String SORT_ORDER_ASC = "asc";
+    public static final String SORT_ORDER_DESC = "desc";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Sorts current list of students in HR+ based on overall rating in descending or ascending order.\n"
+            + "Sorting order can only be either desc or asc.\n"
+            + "Parameters: "
+            + PREFIX_SORT_ORDER + "SORTING ORDER\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_SORT_ORDER + SORT_ORDER_ASC;
+
+    public static final String MESSAGE_INVALID_SORT_ORDER =
+            "The sort order can only be asc or desc";
+    public static final String MESSAGE_RATING_SORT_SUCCESS =
+            "Sorted all students based on overall rating in %1$s order";
+    private static final String SORT_ORDER_ASC_FULL = "ascending";
+    private static final String SORT_ORDER_DESC_FULL = "descending";
+    /**
+     * Enumeration of acceptable sort orders
+     */
+    public enum SortOrder {
+        ASC, DESC
+    }
+
+    private final SortOrder sortOrder;
+
+    public RatingSortCommand(SortOrder sortOrder) {
+        requireNonNull(sortOrder);
+        this.sortOrder = sortOrder;
+    }
+
+    /**
+     * Returns true if a given string is a valid sort order
+     */
+    public static boolean isValidSortOrder(String sortOrder) {
+        requireNonNull(sortOrder);
+        return sortOrder.equals(SORT_ORDER_DESC) || sortOrder.equals(SORT_ORDER_ASC);
+    }
+
+    /**
+     * Returns the string representation of a {@cod SortOrder}
+     */
+    private String getSortOrderString(SortOrder sortOrder) {
+        switch (sortOrder) {
+        case ASC:
+            return SORT_ORDER_ASC_FULL;
+
+        case DESC:
+            return SORT_ORDER_DESC_FULL;
+
+        default:
+            return null;
+        }
+    }
+
+    @Override
+    public CommandResult execute() throws CommandException {
+        switch (sortOrder) {
+        case ASC:
+            model.sortPersonListAscOrder();
+            break;
+
+        case DESC:
+            model.sortPersonListDescOrder();
+            break;
+
+        default:
+            throw new CommandException(MESSAGE_INVALID_SORT_ORDER);
+        }
+        return new CommandResult(String.format(MESSAGE_RATING_SORT_SUCCESS, getSortOrderString(sortOrder)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RatingSortCommand // instanceof handles nulls
+                && this.sortOrder.equals(((RatingSortCommand) other).sortOrder)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.InterviewCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RateCommand;
+import seedu.address.logic.commands.RatingSortCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.StatusCommand;
@@ -100,6 +101,9 @@ public class AddressBookParser {
 
         case DeleteRatingCommand.COMMAND_WORD:
             return new DeleteRatingCommandParser().parse(arguments);
+
+        case RatingSortCommand.COMMAND_WORD:
+            return new RatingSortCommandParser().parse(arguments);
 
         case StatusCommand.COMMAND_WORD:
             return new StatusCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,10 +15,13 @@ public class CliSyntax {
     public static final Prefix PREFIX_GRADE_POINT_AVERAGE = new Prefix("g/");
     public static final Prefix PREFIX_JOB_APPLIED = new Prefix("j/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-    //used only in add/edit command
+    // used only in add/edit command
     public static final Prefix PREFIX_RESUME = new Prefix("r/");
-    //used only in filter command
+    // used only in filter command
     public static final Prefix PREFIX_RATING = new Prefix("r/");
+
+    // used in rating_sort command only
+    public static final Prefix PREFIX_SORT_ORDER = new Prefix("o/");
 
     public static final Prefix PREFIX_TECHNICAL_SKILLS_SCORE = new Prefix("t/");
     public static final Prefix PREFIX_COMMUNICATION_SKILLS_SCORE = new Prefix("c/");

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -11,6 +11,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.DoubleUtil;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.RatingSortCommand;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.ExpectedGraduationYear;
@@ -375,6 +376,37 @@ public class ParserUtil {
         }
         return experienceScore.isPresent() ? Optional.of(parseExperienceScore(
                 experienceScore.get())) : Optional.empty();
+    }
+
+    /**
+     * Parses a {@code String sortOrder} into a {@code RatingSortCommand.SortOrder}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws IllegalValueException if given {@code sortOrder} is invalid.
+     */
+    public static RatingSortCommand.SortOrder parseSortOrder(String sortOrder)
+            throws IllegalValueException {
+        requireNonNull(sortOrder);
+        String trimmedSortOrder = sortOrder.trim();
+        if (!RatingSortCommand.isValidSortOrder(trimmedSortOrder)) {
+            throw new IllegalValueException(RatingSortCommand.MESSAGE_INVALID_SORT_ORDER);
+        }
+        if (trimmedSortOrder.equals(RatingSortCommand.SORT_ORDER_ASC)) {
+            return RatingSortCommand.SortOrder.ASC;
+        } else {
+            return RatingSortCommand.SortOrder.DESC;
+        }
+    }
+
+    /**
+     * Parses a {@code Optional<String> sortOrder} into an {@code Optional<RatingSortCommand.SortOrder>}
+     * if {@code sortOrder} is present.
+     * See header comment of this class regarding the use of {@code Optional} parameters.
+     */
+    public static Optional<RatingSortCommand.SortOrder> parseSortOrder(Optional<String> sortOrder)
+            throws IllegalValueException {
+        requireNonNull(sortOrder);
+        return sortOrder.isPresent() ? Optional.of(parseSortOrder(sortOrder.get())) : Optional.empty();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/RatingSortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RatingSortCommandParser.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_ORDER;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.RatingSortCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class RatingSortCommandParser {
+    public RatingSortCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_SORT_ORDER);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_SORT_ORDER)
+                || !areAllFieldsSupplied(argMultimap, PREFIX_SORT_ORDER)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RatingSortCommand.MESSAGE_USAGE));
+        }
+
+
+        RatingSortCommand.SortOrder sortOrder;
+        try {
+            sortOrder = ParserUtil.parseSortOrder(
+                    argMultimap.getValue(PREFIX_SORT_ORDER)).get();
+        } catch (IllegalValueException ive) {
+            throw new ParseException(ive.getMessage(), ive);
+        }
+        return new RatingSortCommand(sortOrder);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    private static boolean areAllFieldsSupplied(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> !Optional.of(argumentMultimap.getValue(prefix)).equals(""));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/RatingSortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RatingSortCommandParser.java
@@ -11,7 +11,16 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.RatingSortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
+/**
+ * Parses input arguments and creates a new RatingSortCommand object
+ */
 public class RatingSortCommandParser {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the RatingSortCommand
+     * and returns an RatingSortCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public RatingSortCommand parse(String args) throws ParseException {
         requireNonNull(args);
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -77,6 +77,20 @@ public class AddressBook implements ReadOnlyAddressBook {
         }
     }
 
+    /**
+     * Sorts all students in HR+ based on overall rating in ascending order
+     */
+    public void sortAsc() {
+        persons.sortPersonsAsc();
+    }
+
+    /**
+     * Sorts all students in HR+ based on overall rating in descending order
+     */
+    public void sortDesc() {
+        persons.sortPersonsDesc();
+    }
+
     //// person-level operations
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -52,4 +52,14 @@ public interface Model {
 
     void filterFilteredPersonList(Predicate<Person> predicate);
 
+    /**
+     * Sorts the filtered person list based on overall rating in ascending order
+     */
+    void sortPersonListAscOrder();
+
+    /**
+     * Sorts the filtered person list based on overall rating in descending order
+     */
+    void sortPersonListDescOrder();
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -115,6 +115,20 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
+    public void sortPersonListAscOrder() {
+        addressBook.sortAsc();
+        Predicate<? super Person> currPredicate = filteredPersons.getPredicate();
+        filteredPersons.setPredicate(currPredicate);
+    }
+
+    @Override
+    public void sortPersonListDescOrder() {
+        addressBook.sortDesc();
+        Predicate<? super Person> currPredicate = filteredPersons.getPredicate();
+        filteredPersons.setPredicate(currPredicate);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         // short circuit if same object
         if (obj == this) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -166,4 +166,14 @@ public class Person {
         return builder.toString();
     }
 
+    /**
+     * Compares the overall ratings of two {@code Person} objects.
+     * @param p1
+     * @param p2
+     * @return 1 if p1 has a higher overall rating, 0 if p1 and p2 have equal overall rating and -1 otherwise.
+     */
+    public static int compareByOverallRating(Person p1, Person p2) {
+        return Double.compare(p1.getRating().getOverallScore(),
+                p2.getRating().getOverallScore());
+    }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -93,6 +94,22 @@ public class UniquePersonList implements Iterable<Person> {
         }
         setPersons(replacement);
     }
+
+    /**
+     * Sorts the list based on overall rating in ascending order
+     */
+    public void sortPersonsAsc() {
+        Collections.sort(internalList, Person::compareByOverallRating);
+    }
+
+    /**
+     * Sorts the list based on overall rating in descending order
+     */
+    public void sortPersonsDesc() {
+        Collections.sort(internalList, Person::compareByOverallRating);
+        Collections.reverse(internalList);
+    }
+
 
     /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -145,6 +145,16 @@ public class AddCommandTest {
         public void filterFilteredPersonList(Predicate<Person> predicate) {
             fail("This method should not be called.");
         }
+
+        @Override
+        public void sortPersonListAscOrder() {
+            fail("This method should not be called.");
+        }
+
+        @Override
+        public void sortPersonListDescOrder() {
+            fail("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/RateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RateCommandTest.java
@@ -207,7 +207,7 @@ public class RateCommandTest {
     }
 
     /**
-      * Returns an {@code RemarkCommand}.
+      * Returns a {@code RateCommand}.
       */
     private RateCommand prepareCommand(Index index, Rating rating) {
         RateCommand rateCommand = new RateCommand(index, rating);

--- a/src/test/java/seedu/address/logic/commands/RatingSortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RatingSortCommandTest.java
@@ -1,0 +1,92 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.RatingSortCommand.MESSAGE_RATING_SORT_SUCCESS;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.UndoRedoStack;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+public class RatingSortCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute() throws Exception {
+        RatingSortCommand command = prepareCommand(RatingSortCommand.SortOrder.DESC);
+        String expectedMessage = String.format(MESSAGE_RATING_SORT_SUCCESS, "descending");
+
+        assertCommandSuccess(command, expectedMessage, Arrays.asList(
+                BENSON, GEORGE, ALICE, FIONA, ELLE, DANIEL, CARL));
+    }
+
+    @Test
+    public void isValidSortOrder() {
+        assertTrue(RatingSortCommand.isValidSortOrder("asc"));
+        assertTrue(RatingSortCommand.isValidSortOrder("desc"));
+
+        assertFalse(RatingSortCommand.isValidSortOrder(""));
+        assertFalse(RatingSortCommand.isValidSortOrder("ascc"));
+
+    }
+
+    @Test
+    public void equals() {
+        final RatingSortCommand standardCommand = prepareCommand(RatingSortCommand.SortOrder.DESC);
+        // same values -> returns true
+        RatingSortCommand commandWithSameValues = prepareCommand(RatingSortCommand.SortOrder.DESC);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different sort order -> returns false
+        assertFalse(standardCommand.equals(prepareCommand(RatingSortCommand.SortOrder.ASC)));
+    }
+
+    /**
+     * Returns a {@code RatingSortCommand}.
+     */
+    private RatingSortCommand prepareCommand(RatingSortCommand.SortOrder sortOrder) {
+        RatingSortCommand ratingSortCommand = new RatingSortCommand(sortOrder);
+        ratingSortCommand.setData(model, new CommandHistory(), new UndoRedoStack());
+        return ratingSortCommand;
+    }
+
+    /**
+     * Asserts that {@code command} is successfully executed, and<br>
+     *     - the command feedback is equal to {@code expectedMessage}<br>
+     *     - the {@code FilteredList<Person>} is equal to {@code expectedList}<br>
+     *     - the {@code AddressBook} in model remains the same after executing the {@code command}
+     */
+    private void assertCommandSuccess(RatingSortCommand command, String expectedMessage, List<Person> expectedList)
+            throws Exception {
+        CommandResult commandResult = command.execute();
+
+        assertEquals(expectedMessage, commandResult.feedbackToUser);
+        assertEquals(expectedList, model.getFilteredPersonList());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/RatingSortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RatingSortCommandTest.java
@@ -57,9 +57,6 @@ public class RatingSortCommandTest {
         // same object -> returns true
         assertTrue(standardCommand.equals(standardCommand));
 
-        // null -> returns false
-        assertFalse(standardCommand.equals(null));
-
         // different types -> returns false
         assertFalse(standardCommand.equals(new ClearCommand()));
 

--- a/src/test/java/seedu/address/logic/commands/RatingSortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RatingSortCommandTest.java
@@ -34,7 +34,7 @@ public class RatingSortCommandTest {
         String expectedMessage = String.format(MESSAGE_RATING_SORT_SUCCESS, "descending");
 
         assertCommandSuccess(command, expectedMessage, Arrays.asList(
-                BENSON, GEORGE, ALICE, FIONA, ELLE, DANIEL, CARL));
+                BENSON, ALICE, GEORGE, FIONA, ELLE, DANIEL, CARL));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -8,6 +8,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMUNICATION_SKILLS_SCORE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPERIENCE_SCORE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROBLEM_SOLVING_SKILLS_SCORE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_ORDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TECHNICAL_SKILLS_SCORE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -35,6 +36,7 @@ import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.InterviewCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RateCommand;
+import seedu.address.logic.commands.RatingSortCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.StatusCommand;
@@ -134,6 +136,13 @@ public class AddressBookParserTest {
         DeleteRatingCommand command = (DeleteRatingCommand) parser.parseCommand(
                 DeleteRatingCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteRatingCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_ratingSort() throws Exception {
+        RatingSortCommand command = (RatingSortCommand) parser.parseCommand(
+                RatingSortCommand.COMMAND_WORD + " " + PREFIX_SORT_ORDER + RatingSortCommand.SORT_ORDER_ASC);
+        assertEquals(new RatingSortCommand(RatingSortCommand.SortOrder.ASC), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.RatingSortCommand;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -30,12 +31,14 @@ public class ParserUtilTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_SORT_ORDER = "a";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
+    private static final String VALID_SORT_ORDER = "asc";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
 
@@ -192,6 +195,35 @@ public class ParserUtilTest {
         Email expectedEmail = new Email(VALID_EMAIL);
         assertEquals(expectedEmail, ParserUtil.parseEmail(emailWithWhitespace));
         assertEquals(Optional.of(expectedEmail), ParserUtil.parseEmail(Optional.of(emailWithWhitespace)));
+    }
+
+    @Test
+    public void parseSortOrder_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseSortOrder((String) null));
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseEmail((Optional<String>) null));
+    }
+
+    @Test
+    public void parseSortOrder_invalidValue_throwsIllegalValueException() {
+        Assert.assertThrows(
+            IllegalValueException.class, () -> ParserUtil.parseSortOrder(INVALID_SORT_ORDER));
+        Assert.assertThrows(
+            IllegalValueException.class, () -> ParserUtil.parseSortOrder(Optional.of(INVALID_SORT_ORDER)));
+    }
+
+    @Test
+    public void parseSortOrder_validValueWithoutWhitespace_returnsSortOrder() throws Exception {
+        RatingSortCommand.SortOrder expectedSortOrder = RatingSortCommand.SortOrder.ASC;
+        assertEquals(expectedSortOrder, ParserUtil.parseSortOrder(VALID_SORT_ORDER));
+        assertEquals(Optional.of(expectedSortOrder), ParserUtil.parseSortOrder(Optional.of(VALID_SORT_ORDER)));
+    }
+
+    @Test
+    public void parseSortOrder_validValueWithWhitespace_returnsSortOrder() throws Exception {
+        RatingSortCommand.SortOrder expectedSortOrder = RatingSortCommand.SortOrder.ASC;
+        String sortOrderWithWhitespace = WHITESPACE + VALID_SORT_ORDER + WHITESPACE;
+        assertEquals(expectedSortOrder, ParserUtil.parseSortOrder(sortOrderWithWhitespace));
+        assertEquals(Optional.of(expectedSortOrder), ParserUtil.parseSortOrder(Optional.of(sortOrderWithWhitespace)));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -7,6 +7,10 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BENSON_WITH_FRIENDS_TAG_REMOVED;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.CARL_WITHOUT_TAG;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.ArrayList;
@@ -61,6 +65,26 @@ public class AddressBookTest {
 
         thrown.expect(AssertionError.class);
         addressBook.resetData(newData);
+    }
+
+    @Test
+    public void sortDesc() {
+        AddressBook newData = getTypicalAddressBook();
+        newData.sortDesc();
+
+        AddressBook expectedAddressbook = new AddressBookBuilder().withPerson(BENSON).withPerson(ALICE)
+                .withPerson(GEORGE).withPerson(FIONA).withPerson(ELLE).withPerson(DANIEL).withPerson(CARL).build();
+        assertEquals(expectedAddressbook.getPersonList(), newData.getPersonList());
+    }
+
+    @Test
+    public void sortAsc() {
+        AddressBook newData = getTypicalAddressBook();
+        newData.sortAsc();
+
+        AddressBook expectedAddressbook = new AddressBookBuilder().withPerson(CARL).withPerson(DANIEL)
+                .withPerson(ELLE).withPerson(FIONA).withPerson(GEORGE).withPerson(ALICE).withPerson(BENSON).build();
+        assertEquals(expectedAddressbook.getPersonList(), newData.getPersonList());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BENSON_WITH_FRIENDS_TAG_REMOVED;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.CARL_WITHOUT_TAG;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
 
 import java.util.Arrays;
 
@@ -91,6 +92,32 @@ public class ModelManagerTest {
 
         ModelManager modelManager = new ModelManager(addressBook, userPrefs);
         modelManager.deleteTag(new Tag("friends"));
+        assertEquals(modelManager, new ModelManager(expectedAddressBook, userPrefs));
+    }
+
+    @Test
+    public void sortPersonListAscOrder() {
+        AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON)
+                .withPerson(GEORGE).build();
+        UserPrefs userPrefs = new UserPrefs();
+        AddressBook expectedAddressBook = new AddressBookBuilder().withPerson(GEORGE)
+                .withPerson(ALICE).withPerson(BENSON).build();
+
+        ModelManager modelManager = new ModelManager(addressBook, userPrefs);
+        modelManager.sortPersonListAscOrder();
+        assertEquals(modelManager, new ModelManager(expectedAddressBook, userPrefs));
+    }
+
+    @Test
+    public void sortPersonListDescOrder() {
+        AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON)
+                .withPerson(GEORGE).build();
+        UserPrefs userPrefs = new UserPrefs();
+        AddressBook expectedAddressBook = new AddressBookBuilder().withPerson(BENSON)
+                .withPerson(ALICE).withPerson(GEORGE).build();
+
+        ModelManager modelManager = new ModelManager(addressBook, userPrefs);
+        modelManager.sortPersonListDescOrder();
         assertEquals(modelManager, new ModelManager(expectedAddressBook, userPrefs));
     }
 }


### PR DESCRIPTION
Fixes #63 

1. The format of the command is `rating_sort o/Sort Order`. Only "asc" (ascending order) and "desc" (descending order) are accepted as valid parameters. If the students have been filtered, sorting will only run on the current list of students instead of all students in HR+.
2. Update tests and User Guide.